### PR TITLE
Configure Multistage Build for the Development Environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /opt/app
 COPY . /opt/app
 
 # Build source and clean up
-RUN npm run build && npm uninstall --only=dev
+RUN npm run build
 
 FROM node:8-alpine
 # Defaults the node environment to production, however compose will override this to use development
@@ -31,6 +31,11 @@ EXPOSE $PORT 5858 9229
 
 WORKDIR /opt
 COPY --from=builder /opt/ .
+
+# Uninstall dev dependencies for the production image
+WORKDIR /opt
+RUN npm uninstall --only=dev
+
 WORKDIR /opt/app/dist
 # Run the container! Using the node command instead of npm allows for better passing of signals
 # and graceful shutdown. Further examination would be useful here.


### PR DESCRIPTION
I have moved the uninstall of dev dependencies to the production image so that local development can target just the builder stage. This preserves the dev dependencies when a developer is working on the project locally, allowing the use of nodemon and gulp within the container.