### PR TITLE
Route for Client Version Check 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "1.2.1",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4484,6 +4484,11 @@
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.0.0.tgz",
       "integrity": "sha1-ICtIAhoMTL3i34DeFaF0Q8i0OYA="
     },
+    "node-fetch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
+      "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
+    },
     "nodemon": {
       "version": "1.18.4",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "helmet": "^3.6.1",
     "jsonwebtoken": "^8.3.0",
     "morgan": "^1.9.0",
+    "node-fetch": "^2.2.0",
     "raven": "^2.3.0",
     "request": "^2.85.0",
     "socket.io": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/TokenManager.ts
+++ b/src/drivers/TokenManager.ts
@@ -9,7 +9,7 @@ import * as jwt from 'jsonwebtoken';
 export function verifyJWT(
   token: string,
   res: any,
-  callback: Function
+  callback: Function,
 ): boolean {
   try {
     const decoded = jwt.verify(token, process.env.KEY, {});
@@ -30,11 +30,11 @@ export function decode(token: string): Promise<any> {
       token,
       process.env.KEY,
       {
-        issuer: process.env.ISSUER
+        issuer: process.env.ISSUER,
       },
       (err: any, decoded: any) => {
         err ? reject(err) : resolve(decoded);
-      }
+      },
     );
   });
 }

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -159,7 +159,7 @@ export default class ExpressRouteDriver {
           res.sendStatus(200);
         } else {
           // Http 426 - Upgrade Required
-          res.status(426).send('A new version of the CLARK client is availble. Please refresh your page.');
+          res.status(426).send('A new version of CLARK is available! . Refresh your page to see our latest changes');
         }
       } catch (e) {
         res.status(500).send('Could not recover the client version');

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -53,6 +53,7 @@ export default class ExpressRouteDriver {
         message: 'Welcome to the C.L.A.R.K. Gateway API',
       });
     });
+
     router.use('/users', this.buildUserRouter());
     router.use(
       '/users/:username/learning-objects',
@@ -140,6 +141,15 @@ export default class ExpressRouteDriver {
         this.getResponder(res).sendOperationError(
           `Problem checking status. Error: ${e}.`,
         );
+      }
+    });
+
+    router.get('/clientversion/:clientVersion', function(req, res) {
+      if (req.params.clientVersion === process.env.CLIENT_VERSION) {
+        res.sendStatus(200);
+      } else {
+        // Http 426 - Upgrade Required
+        res.status(426).send('A new version of the CLARK client is availble. Please refresh your page.');
       }
     });
 

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -6,6 +6,7 @@ import * as querystring from 'querystring';
 import * as dotenv from 'dotenv';
 import { LEARNING_OBJECT_ROUTES, BUSINESS_CARD_ROUTES } from '../../routes';
 import * as request from 'request';
+import fetch from 'node-fetch';
 import { SocketInteractor } from '../../interactors/SocketInteractor';
 
 dotenv.config();
@@ -149,12 +150,19 @@ export default class ExpressRouteDriver {
       }
     });
 
-    router.get('/clientversion/:clientVersion', function(req, res) {
-      if (req.params.clientVersion === process.env.CLIENT_VERSION) {
-        res.sendStatus(200);
-      } else {
-        // Http 426 - Upgrade Required
-        res.status(426).send('A new version of the CLARK client is availble. Please refresh your page.');
+    router.get('/clientversion/:clientVersion', async (req, res) => {
+      try {
+        const response = await fetch(process.env.CLIENTVERSIONURL);
+        const object = await response.json();
+        const version: string = object.version;
+        if (req.params.clientVersion === version) {
+          res.sendStatus(200);
+        } else {
+          // Http 426 - Upgrade Required
+          res.status(426).send('A new version of the CLARK client is availble. Please refresh your page.');
+        }
+      } catch (e) {
+        res.status(500).send('Could not recover the client version');
       }
     });
 

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -89,8 +89,8 @@ export default class ExpressRouteDriver {
     router.get('/collections', proxy(LEARNING_OBJECT_SERVICE_URI, {
       proxyReqPathResolver: req => {
         return LEARNING_OBJECT_ROUTES.GET_COLLECTIONS;
-      }
-    }))
+      },
+    }));
     router.get(
       '/users/identifiers/active',
       proxy(USERS_API, {

--- a/src/drivers/middleware/jwt.config.ts
+++ b/src/drivers/middleware/jwt.config.ts
@@ -17,6 +17,7 @@ export const enforceTokenAccess = jwt({
   path: [
     '/',
     { url: /\/users\/[0-z,.,-]+/i, methods: ['GET'] },
+    /\/clientversion\/[0-z,.,-]/,
     '/users/ota-codes',
     '/users/validate-captcha',
     '/users/identifiers/active',


### PR DESCRIPTION
This PR adds a new route '/clientversion/:clientVersion' to gateway. Once this route is hit, gateway makes a request to grab the current client version. The URL for this is stored in a new env 'CLIENTVERISONURL'. The route checks to ensure that the version received from the client matches the current client version. If the client version is up-to-date, gateway will return status 200. If there is a version mismatch, gateway will return status 426 (upgrade required). Finally, the route will return a 500 if it is unable to make a request to grab the current client version. 