### PR TITLE
Add proxy to library stats route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -60,6 +60,15 @@ export default class ExpressRouteDriver {
       });
     });
 
+    router.get(
+      '/library/stats',
+      proxy(CART_API, {
+        proxyReqPathResolver: req => {
+          return `/library/stats`;
+        },
+      }),
+    );
+
     router.use('/users', this.buildUserRouter());
     router.use(
       '/users/:username/learning-objects',


### PR DESCRIPTION
This PR adds proxy route to library stats route

Contributes to Cyber4All/clark-client#606
Needs Cyber4All/library-service#92