### PR TITLE
Add library stats route to unless block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/middleware/jwt.config.ts
+++ b/src/drivers/middleware/jwt.config.ts
@@ -35,6 +35,7 @@ export const enforceTokenAccess = jwt({
     '/status',
     '/collections',
     /\/users\/[0-z,.,-]+\/cards/i,
+    '/library/stats',
   ],
 }); // register // all ota-code routes do their own verification outsides of JWT // login
 // TODO: Whitelist user routes


### PR DESCRIPTION
The library stats needs to be added to the unless block of the JWT middleware to allow public access.

I suggest that in the future, we consider removing the JWT middleware here for any route that serves as a proxy to another service, and just allow that service to handle authentication. 