### PR TITLE
Update proxy routes for multipart uploads to new API routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -726,7 +726,9 @@ export default class ExpressRouteDriver {
     router.route('/:objectId/files/:fileId/multipart').all(
       proxy(LEARNING_OBJECT_SERVICE_URI, {
         proxyReqPathResolver: req => {
+          const username = parentParams.username;
           return FILE_UPLOAD_ROUTES.HANDLE_MULTIPART({
+            username,
             objectId: req.params.objectId,
             fileId: req.params.fileId,
           });

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -80,10 +80,14 @@ export const LEARNING_OBJECT_ROUTES = {
 };
 
 export const FILE_UPLOAD_ROUTES = {
-  HANDLE_MULTIPART(params: { objectId: string; fileId: string }) {
-    return `/learning-objects/${params.objectId}/files/${
-      params.fileId
-    }/multipart`;
+  HANDLE_MULTIPART(params: {
+    username: string;
+    objectId: string;
+    fileId: string;
+  }) {
+    return `/users/${encodeURIComponent(params.username)}/learning-objects/${
+      params.objectId
+    }/files/${params.fileId}/multipart`;
   },
 };
 


### PR DESCRIPTION
This PR updates the routes used for proxying multipart upload requests.

Needs Cyber4All/learning-object-service#272.