### PR TITLE
add proxies for collection membership modification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -298,6 +298,42 @@ export default class ExpressRouteDriver {
       }),
     );
 
+    router.put(
+      '/users/:collectionName/members/:memberId',
+      proxy(USERS_API, {
+        proxyReqPathResolver: req => {
+          return ADMIN_USER_ROUTES.ASSIGN_COLLECTION_MEMBERSHIP(
+            req.params.collectionName,
+            req.params.memberId,
+          );
+        },
+      }),
+    );
+    
+    router.patch(
+      '/users/:collectionName/members/:memberId',
+      proxy(USERS_API, {
+        proxyReqPathResolver: req => {
+          return ADMIN_USER_ROUTES.EDIT_COLLECTION_MEMBERSHIP(
+            req.params.collectionName,
+            req.params.memberId,
+          );
+        },
+      }),
+    );
+
+    router.delete(
+      '/users/:collectionName/members/:memberId',
+      proxy(USERS_API, {
+        proxyReqPathResolver: req => {
+          return ADMIN_USER_ROUTES.REMOVE_COLLECTION_MEMBERSHIP (
+            req.params.collectionName,
+            req.params.memberId,
+          );
+        },
+      }),
+    );
+
     router.get(
       '/count/:author',
       proxy(CART_API, {

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -299,7 +299,7 @@ export default class ExpressRouteDriver {
     );
 
     router.put(
-      '/users/:collectionName/members/:memberId',
+      '/collections/:collectionName/members/:memberId',
       proxy(USERS_API, {
         proxyReqPathResolver: req => {
           return ADMIN_USER_ROUTES.ASSIGN_COLLECTION_MEMBERSHIP(
@@ -311,7 +311,7 @@ export default class ExpressRouteDriver {
     );
     
     router.patch(
-      '/users/:collectionName/members/:memberId',
+      '/collections/:collectionName/members/:memberId',
       proxy(USERS_API, {
         proxyReqPathResolver: req => {
           return ADMIN_USER_ROUTES.EDIT_COLLECTION_MEMBERSHIP(
@@ -323,7 +323,7 @@ export default class ExpressRouteDriver {
     );
 
     router.delete(
-      '/users/:collectionName/members/:memberId',
+      '/collections/:collectionName/members/:memberId',
       proxy(USERS_API, {
         proxyReqPathResolver: req => {
           return ADMIN_USER_ROUTES.REMOVE_COLLECTION_MEMBERSHIP (

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -155,7 +155,7 @@ export const ADMIN_USER_ROUTES = {
     )}/reviewers`;
   },
   ASSIGN_COLLECTION_MEMBERSHIP(collectionName: string, memberId: string) {
-    return `/users/${encodeURIComponent(
+    return `/collections/${encodeURIComponent(
       collectionName,
     )}/members/
     ${encodeURIComponent(
@@ -163,7 +163,7 @@ export const ADMIN_USER_ROUTES = {
     )}`;
   },
   EDIT_COLLECTION_MEMBERSHIP(collectionName: string, memberId: string) {
-    return `/users/${encodeURIComponent(
+    return `/collections/${encodeURIComponent(
       collectionName,
     )}/members/
     ${encodeURIComponent(
@@ -171,7 +171,7 @@ export const ADMIN_USER_ROUTES = {
     )}`;
   },
   REMOVE_COLLECTION_MEMBERSHIP(collectionName: string, memberId: string) {
-    return `/users/${encodeURIComponent(
+    return `/collections/${encodeURIComponent(
       collectionName,
     )}/members/
     ${encodeURIComponent(

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -154,6 +154,30 @@ export const ADMIN_USER_ROUTES = {
       collectionName,
     )}/reviewers`;
   },
+  ASSIGN_COLLECTION_MEMBERSHIP(collectionName: string, memberId: string) {
+    return `/users/${encodeURIComponent(
+      collectionName,
+    )}/members/
+    ${encodeURIComponent(
+      memberId,
+    )}`;
+  },
+  EDIT_COLLECTION_MEMBERSHIP(collectionName: string, memberId: string) {
+    return `/users/${encodeURIComponent(
+      collectionName,
+    )}/members/
+    ${encodeURIComponent(
+      memberId,
+    )}`;
+  },
+  REMOVE_COLLECTION_MEMBERSHIP(collectionName: string, memberId: string) {
+    return `/users/${encodeURIComponent(
+      collectionName,
+    )}/members/
+    ${encodeURIComponent(
+      memberId,
+    )}`;
+  },
 };
 
 export const ADMIN_MAILER_ROUTES = {


### PR DESCRIPTION
Add proxies for collection membership assign, edit, and remove routes in user service.


#Required by https://github.com/Cyber4All/clark-client/pull/709
#Required by https://github.com/Cyber4All/user-service/pull/127