### PR TITLE
Update route for downloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.8.0",
+  "version": "2.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.8.0",
+  "version": "2.8.2",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -568,7 +568,9 @@ export default class ExpressRouteDriver {
           proxyReqPathResolver: req => {
             return `/users/${encodeURIComponent(
               req.params.username,
-            )}/cart/learning-objects/${req.params.author}/${encodeURIComponent(
+            )}/cart/learning-objects/${encodeURIComponent(
+              req.params.author,
+              )}/${encodeURIComponent(
               req.params.learningObjectName,
             )}`;
           },
@@ -588,15 +590,13 @@ export default class ExpressRouteDriver {
       );
 
     router
-      .route('/:username/library/learning-objects/:author/:learningObjectName')
+      .route('/:username/learning-objects/:learningObjectName/bundle')
       .get(
         proxy(CART_API, {
           proxyReqPathResolver: req => {
             return `/users/${encodeURIComponent(
               req.params.username,
-            )}/library/learning-objects/${
-              req.params.author
-            }/${encodeURIComponent(req.params.learningObjectName)}`;
+            )}/learning-objects/${encodeURIComponent(req.params.learningObjectName)}/bundle?${querystring.stringify(req.query)}`;
           },
         }),
       );


### PR DESCRIPTION
This is to update the route that handles downloads for both working and released copies of a learning object. 

Required by Cyber4All/clark-client#723