### PR TITLE
Fix Add Materials Proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -76,7 +76,7 @@ export const LEARNING_OBJECT_ROUTES = {
     return `/learning-objects/${id}/materials/all`;
   },
   ADD_MATERIALS(username: string, id: string) {
-    return `users/${encodeURIComponent(username)}/learning-objects/${id}/materials/files`;
+    return `/users/${encodeURIComponent(username)}/learning-objects/${id}/materials/files`;
   },
   GET_LEARNING_OBJECT_CHILDREN(learningObjectID: string) {
     return `/learning-objects/${encodeURIComponent(


### PR DESCRIPTION
The route was missing a forward slash causing Gateway to send a 400 error response.