### PR TITLE
Update proxy for file meta update and delete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.9.2-1",
+  "version": "2.9.3",
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.9.2-1",
+  "version": "2.9.3",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -777,23 +777,66 @@ export default class ExpressRouteDriver {
       }),
     );
     // FILE OPERATIONS
+    /**
+     * TODO: Deprecate in favor of more RESTful `/:learningObjectId/materials/files/:fileId` when clients have updated
+     */
     router
       .route('/:learningObjectID/files/:fileId')
       .patch(
         proxy(LEARNING_OBJECT_SERVICE_URI, {
           proxyReqPathResolver: req => {
-            const id = req.params.learningObjectID;
+            const username = parentParams.username;
+            const learningObjectId = req.params.learningObjectID;
             const fileId = req.params.fileId;
-            return LEARNING_OBJECT_ROUTES.UPDATE_FILE(id, fileId);
+            return LEARNING_OBJECT_ROUTES.UPDATE_FILE({
+              username,
+              learningObjectId,
+              fileId,
+            });
           },
         }),
       )
       .delete(
         proxy(LEARNING_OBJECT_SERVICE_URI, {
           proxyReqPathResolver: req => {
-            const id = req.params.learningObjectID;
+            const username = parentParams.username;
+            const learningObjectId = req.params.learningObjectID;
             const fileId = req.params.fileId;
-            return LEARNING_OBJECT_ROUTES.DELETE_FILE(id, fileId);
+            return LEARNING_OBJECT_ROUTES.UPDATE_FILE({
+              username,
+              learningObjectId,
+              fileId,
+            });
+          },
+        }),
+      );
+    router
+      .route('/:learningObjectId/materials/files/:fileId')
+      .patch(
+        proxy(LEARNING_OBJECT_SERVICE_URI, {
+          proxyReqPathResolver: req => {
+            const username = parentParams.username;
+            const learningObjectId = req.params.learningObjectId;
+            const fileId = req.params.fileId;
+            return LEARNING_OBJECT_ROUTES.UPDATE_FILE({
+              username,
+              learningObjectId,
+              fileId,
+            });
+          },
+        }),
+      )
+      .delete(
+        proxy(LEARNING_OBJECT_SERVICE_URI, {
+          proxyReqPathResolver: req => {
+            const username = parentParams.username;
+            const learningObjectId = req.params.learningObjectID;
+            const fileId = req.params.fileId;
+            return LEARNING_OBJECT_ROUTES.UPDATE_FILE({
+              username,
+              learningObjectId,
+              fileId,
+            });
           },
         }),
       );

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -39,11 +39,11 @@ export const LEARNING_OBJECT_ROUTES = {
   },
 
   UPLOAD_MATERIALS: `/files`,
-  UPDATE_FILE(id: string, fileId: string) {
-    return `/files/${id}/${encodeURIComponent(fileId)}`;
+  UPDATE_FILE({ username, learningObjectId, fileId }: { username: string; learningObjectId: string; fileId: string; }) {
+    return `/users/${username}/learning-objects/${learningObjectId}/materials/files/${encodeURIComponent(fileId)}`;
   },
-  DELETE_FILE(id: string, fileId: string) {
-    return `/files/${id}/${encodeURIComponent(fileId)}`;
+  DELETE_FILE({ username, learningObjectId, fileId }: { username: string; learningObjectId: string; fileId: string; }) {
+    return `/users/${username}/learning-objects/${learningObjectId}/materials/files/${encodeURIComponent(fileId)}`;
   },
   FETCH_MULTIPLE_LEARNING_OBJECTS: '/learning-objects/multiple',
   ADD_LEARNING_OBJECT_TO_COLLECTION(id: string) {


### PR DESCRIPTION
This PR updates proxy for updating and deleting file metadata from `/learning-objects/:learningObjectId/files/:fileId` to `/users/:username/learning-objects/:learningObjectId/materials/files/:fileId` which will be introduced [here](https://github.com/Cyber4All/learning-object-service/pull/391).

This is update is in efforts to make routes more RESTful and consistent across the system.

Note: To maintain backward compatibility, the old routes will not be removed until clients have updated. 

Dependent on https://github.com/Cyber4All/learning-object-service/pull/391