### PR TITLE
Update materials route to allow query parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -823,7 +823,11 @@ export default class ExpressRouteDriver {
         proxyReqPathResolver: req => {
           const username = parentParams.username;
           const id = req.params.id;
-          return LEARNING_OBJECT_ROUTES.GET_MATERIALS(username, id);
+          return LEARNING_OBJECT_ROUTES.GET_MATERIALS({
+            username,
+            id,
+            query: req.query,
+          });
         },
       }),
     );

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -821,8 +821,9 @@ export default class ExpressRouteDriver {
     router.route('/:id/materials').get(
       proxy(LEARNING_OBJECT_SERVICE_URI, {
         proxyReqPathResolver: req => {
+          const username = parentParams.username;
           const id = req.params.id;
-          return LEARNING_OBJECT_ROUTES.GET_MATERIALS(id);
+          return LEARNING_OBJECT_ROUTES.GET_MATERIALS(username, id);
         },
       }),
     );

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -72,8 +72,8 @@ export const LEARNING_OBJECT_ROUTES = {
       params.fileId
     }/download?${querystring.stringify(params.query)}`;
   },
-  GET_MATERIALS(id: string) {
-    return `/learning-objects/${id}/materials/all`;
+  GET_MATERIALS(username: string, id: string) {
+    return `/users/${encodeURIComponent(username)}/learning-objects/${id}/materials`;
   },
   ADD_MATERIALS(username: string, id: string) {
     return `/users/${encodeURIComponent(username)}/learning-objects/${id}/materials/files`;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -72,8 +72,8 @@ export const LEARNING_OBJECT_ROUTES = {
       params.fileId
     }/download?${querystring.stringify(params.query)}`;
   },
-  GET_MATERIALS(username: string, id: string) {
-    return `/users/${encodeURIComponent(username)}/learning-objects/${id}/materials`;
+  GET_MATERIALS({ username, id, query }: { username: string; id: string; query?: any; }) {
+    return `/users/${encodeURIComponent(username)}/learning-objects/${id}/materials?${querystring.stringify(query)}`;
   },
   ADD_MATERIALS(username: string, id: string) {
     return `/users/${encodeURIComponent(username)}/learning-objects/${id}/materials/files`;


### PR DESCRIPTION
This PR updates the proxy route for materials to forward query parameters.

Dependent on https://github.com/Cyber4All/learning-object-service/pull/394