### PR TITLE
Fix typo in proxy route for deleting file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -830,7 +830,7 @@ export default class ExpressRouteDriver {
         proxy(LEARNING_OBJECT_SERVICE_URI, {
           proxyReqPathResolver: req => {
             const username = parentParams.username;
-            const learningObjectId = req.params.learningObjectID;
+            const learningObjectId = req.params.learningObjectId;
             const fileId = req.params.fileId;
             return LEARNING_OBJECT_ROUTES.UPDATE_FILE({
               username,


### PR DESCRIPTION
**Purpose of this PR**
Fixes a typo causing `undefined` to be set for Learning Object Id when making the proxy request to delete file.

**Changes in this PR**
`req.params.learningObjectID` was updated to `req.params.learningObjectId`