### PR TITLE
Update routes for creating updating and deleting Learning Objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -715,7 +715,14 @@ export default class ExpressRouteDriver {
         proxy(LEARNING_OBJECT_SERVICE_URI, {
           proxyReqPathResolver: req => {
             const authorUsername = parentParams.username;
-            return LEARNING_OBJECT_ROUTES.CREATE_LEARNING_OBJECT(authorUsername);
+      );
+
+    router.delete(
+      '/:learningObjectName',
+      proxy(LEARNING_OBJECT_SERVICE_URI, {
+        proxyReqPathResolver: req => {
+          const learningObjectName = req.params.learningObjectName;
+          return LEARNING_OBJECT_ROUTES.DELETE_LEARNING_OBJECT_BY_NAME(learningObjectName);
           },
         }),
       );

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -475,7 +475,9 @@ export default class ExpressRouteDriver {
       '/:id/tokens',
       proxy(USERS_API, {
         proxyReqPathResolver: req => {
-          return `/users/${req.params.id}/tokens?${querystring.stringify(req.query)}`;
+          return `/users/${req.params.id}/tokens?${querystring.stringify(
+            req.query,
+          )}`;
         },
       }),
     );
@@ -504,7 +506,7 @@ export default class ExpressRouteDriver {
           return LEARNING_OBJECT_ROUTES.SUBMIT_FOR_REVIEW(
             req.params.userId,
             req.params.learningObjectId,
-            req.query
+            req.query,
           );
         },
       }),
@@ -553,21 +555,21 @@ export default class ExpressRouteDriver {
         },
         // @ts-ignore
         userResDecorator: function(proxyRes, proxyResData, userReq, userRes) {
-        try {
-          let data = JSON.parse(proxyResData.toString('utf8'));
-          if (data.username) {
-            SocketInteractor.init().sendMessage(
-              data.username,
-              'VERIFIED_EMAIL',
-            );
-            userRes.redirect('http://clark.center');
-            return '';
-          } else {
+          try {
+            let data = JSON.parse(proxyResData.toString('utf8'));
+            if (data.username) {
+              SocketInteractor.init().sendMessage(
+                data.username,
+                'VERIFIED_EMAIL',
+              );
+              userRes.redirect('http://clark.center');
+              return '';
+            } else {
+              return proxyResData;
+            }
+          } catch (e) {
             return proxyResData;
           }
-        } catch (e) {
-          return proxyResData;
-        }
         },
       }),
     );
@@ -603,9 +605,7 @@ export default class ExpressRouteDriver {
               req.params.username,
             )}/cart/learning-objects/${encodeURIComponent(
               req.params.author,
-              )}/${encodeURIComponent(
-              req.params.learningObjectName,
-            )}`;
+            )}/${encodeURIComponent(req.params.learningObjectName)}`;
           },
         }),
       )
@@ -622,17 +622,17 @@ export default class ExpressRouteDriver {
         }),
       );
 
-    router
-      .route('/:username/learning-objects/:learningObjectName/bundle')
-      .get(
-        proxy(CART_API, {
-          proxyReqPathResolver: req => {
-            return `/users/${encodeURIComponent(
-              req.params.username,
-            )}/learning-objects/${encodeURIComponent(req.params.learningObjectName)}/bundle?${querystring.stringify(req.query)}`;
-          },
-        }),
-      );
+    router.route('/:username/learning-objects/:learningObjectName/bundle').get(
+      proxy(CART_API, {
+        proxyReqPathResolver: req => {
+          return `/users/${encodeURIComponent(
+            req.params.username,
+          )}/learning-objects/${encodeURIComponent(
+            req.params.learningObjectName,
+          )}/bundle?${querystring.stringify(req.query)}`;
+        },
+      }),
+    );
 
     router.get(
       '/search',
@@ -715,6 +715,11 @@ export default class ExpressRouteDriver {
         proxy(LEARNING_OBJECT_SERVICE_URI, {
           proxyReqPathResolver: req => {
             const authorUsername = parentParams.username;
+            return LEARNING_OBJECT_ROUTES.CREATE_LEARNING_OBJECT(
+              authorUsername,
+            );
+          },
+        }),
       );
 
     router.delete(
@@ -723,9 +728,9 @@ export default class ExpressRouteDriver {
         proxyReqPathResolver: req => {
           const learningObjectName = req.params.learningObjectName;
           return LEARNING_OBJECT_ROUTES.DELETE_LEARNING_OBJECT_BY_NAME(learningObjectName);
-          },
-        }),
-      );
+        },
+      }),
+    );
 
     router
       .route('/:learningObjectId')
@@ -734,23 +739,25 @@ export default class ExpressRouteDriver {
           proxyReqPathResolver: req => {
             const authorUsername = parentParams.username;
             const learningObjectId = req.params.learningObjectId;
-            return LEARNING_OBJECT_ROUTES.UPDATE_LEARNING_OBJECT(
-              { authorUsername, id: learningObjectId },
-            );
+            return LEARNING_OBJECT_ROUTES.UPDATE_LEARNING_OBJECT({
+              authorUsername,
+              id: learningObjectId,
+            });
           },
         }),
       )
       .delete(
-      proxy(LEARNING_OBJECT_SERVICE_URI, {
-        proxyReqPathResolver: req => {
+        proxy(LEARNING_OBJECT_SERVICE_URI, {
+          proxyReqPathResolver: req => {
             const authorUsername = parentParams.username;
             const learningObjectId = req.params.learningObjectId;
-          return LEARNING_OBJECT_ROUTES.DELETE_LEARNING_OBJECT(
-              { authorUsername, id: learningObjectId },
-          );
-        },
-      }),
-    );
+            return LEARNING_OBJECT_ROUTES.DELETE_LEARNING_OBJECT({
+              authorUsername,
+              id: learningObjectId,
+            });
+          },
+        }),
+      );
 
     router.get(
       '/profile',
@@ -925,31 +932,34 @@ export default class ExpressRouteDriver {
         },
       }),
     );
-    router.route('/:objectId/files/:fileId/multipart/:uploadId/admin').patch(
-      proxy(FILE_UPLOAD_API, {
-        proxyReqPathResolver: req => {
-          const username = parentParams.username;
-          return FILE_UPLOAD_ROUTES.FINALIZE_MULTIPART({
-            username,
-            objectId: req.params.objectId,
-            fileId: req.params.fileId,
-            uploadId: req.params.uploadId,
-          });
-        },
-      }),
-    ).delete(
-      proxy(FILE_UPLOAD_API, {
-        proxyReqPathResolver: req => {
-          const username = parentParams.username;
-          return FILE_UPLOAD_ROUTES.ABORT_MULTIPART({
-            username,
-            objectId: req.params.objectId,
-            fileId: req.params.fileId,
-            uploadId: req.params.uploadId,
-          });
-        },
-      }),
-    );
+    router
+      .route('/:objectId/files/:fileId/multipart/:uploadId/admin')
+      .patch(
+        proxy(FILE_UPLOAD_API, {
+          proxyReqPathResolver: req => {
+            const username = parentParams.username;
+            return FILE_UPLOAD_ROUTES.FINALIZE_MULTIPART({
+              username,
+              objectId: req.params.objectId,
+              fileId: req.params.fileId,
+              uploadId: req.params.uploadId,
+            });
+          },
+        }),
+      )
+      .delete(
+        proxy(FILE_UPLOAD_API, {
+          proxyReqPathResolver: req => {
+            const username = parentParams.username;
+            return FILE_UPLOAD_ROUTES.ABORT_MULTIPART({
+              username,
+              objectId: req.params.objectId,
+              fileId: req.params.fileId,
+              uploadId: req.params.uploadId,
+            });
+          },
+        }),
+      );
     return router(_req, res, next);
   }
 

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -714,17 +714,32 @@ export default class ExpressRouteDriver {
       .post(
         proxy(LEARNING_OBJECT_SERVICE_URI, {
           proxyReqPathResolver: req => {
-            return LEARNING_OBJECT_ROUTES.CREATE_LEARNING_OBJECT;
+            const authorUsername = parentParams.username;
+            return LEARNING_OBJECT_ROUTES.CREATE_LEARNING_OBJECT(authorUsername);
           },
         }),
       );
 
-    router.route('/:learningObjectName').delete(
+    router
+      .route('/:learningObjectId')
+      .patch(
+        proxy(LEARNING_OBJECT_SERVICE_URI, {
+          proxyReqPathResolver: req => {
+            const authorUsername = parentParams.username;
+            const learningObjectId = req.params.learningObjectId;
+            return LEARNING_OBJECT_ROUTES.UPDATE_LEARNING_OBJECT(
+              { authorUsername, id: learningObjectId },
+            );
+          },
+        }),
+      )
+      .delete(
       proxy(LEARNING_OBJECT_SERVICE_URI, {
         proxyReqPathResolver: req => {
-          let learningObjectName = req.params.learningObjectName;
+            const authorUsername = parentParams.username;
+            const learningObjectId = req.params.learningObjectId;
           return LEARNING_OBJECT_ROUTES.DELETE_LEARNING_OBJECT(
-            learningObjectName,
+              { authorUsername, id: learningObjectId },
           );
         },
       }),
@@ -736,17 +751,6 @@ export default class ExpressRouteDriver {
         proxyReqPathResolver: req => {
           return LEARNING_OBJECT_ROUTES.LOAD_USER_PROFILE(
             encodeURIComponent(req.params.username),
-          );
-        },
-      }),
-    );
-
-    router.patch(
-      '/:learningObjectId',
-      proxy(LEARNING_OBJECT_SERVICE_URI, {
-        proxyReqPathResolver: req => {
-          return LEARNING_OBJECT_ROUTES.UPDATE_LEARNING_OBJECT(
-            encodeURIComponent(req.params.learningObjectId),
           );
         },
       }),

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,8 +1,10 @@
 import * as querystring from 'querystring';
 export const LEARNING_OBJECT_ROUTES = {
-  CREATE_LEARNING_OBJECT: '/learning-objects',
-  UPDATE_LEARNING_OBJECT(id: string) {
-    return '/learning-objects/' + encodeURIComponent(id);
+  CREATE_LEARNING_OBJECT(authorUsername: string) {
+    return `/users/${encodeURIComponent(authorUsername)}/learning-objects`;
+  },
+  UPDATE_LEARNING_OBJECT({ authorUsername, id }: { authorUsername: string; id: string; }) {
+    return `/users/${encodeURIComponent(authorUsername)}/learning-objects/${encodeURIComponent(id)}`;
   },
   LOAD_LEARNING_OBJECT(username: string, learningObjectName: string) {
     return `/learning-objects/${encodeURIComponent(
@@ -20,8 +22,8 @@ export const LEARNING_OBJECT_ROUTES = {
       username,
     )}/${encodeURIComponent(learningObjectName)}/id`;
   },
-  DELETE_LEARNING_OBJECT(learningObjectName: string) {
-    return `/learning-objects/${encodeURIComponent(learningObjectName)}`;
+  DELETE_LEARNING_OBJECT({ authorUsername, id }: { authorUsername: string; id: string; }) {
+    return `/users/${encodeURIComponent(authorUsername)}/learning-objects/${encodeURIComponent(id)}`;
   },
   PUBLISH_LEARNING_OBJECT: `/learning-objects/publish`,
   UNPUBLISH_LEARNING_OBJECT: `/learning-objects/unpublish`,

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -22,6 +22,9 @@ export const LEARNING_OBJECT_ROUTES = {
       username,
     )}/${encodeURIComponent(learningObjectName)}/id`;
   },
+  DELETE_LEARNING_OBJECT_BY_NAME(learningObjectName: string) {
+    return `/learning-objects/${encodeURIComponent(learningObjectName)}`;
+  },
   DELETE_LEARNING_OBJECT({ authorUsername, id }: { authorUsername: string; id: string; }) {
     return `/users/${encodeURIComponent(authorUsername)}/learning-objects/${encodeURIComponent(id)}`;
   },


### PR DESCRIPTION
This PR updates the proxy routes for creating, updating, and deleting Learning Objects.

Dependent on https://github.com/Cyber4All/learning-object-service/pull/400