### PR TITLE
Allow configurable keep alive timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.12.0",
+  "version": "2.12.0-1",
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.12.0",
+  "version": "2.12.0-1",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/express/ExpressDriver.ts
+++ b/src/drivers/express/ExpressDriver.ts
@@ -13,6 +13,8 @@ import * as dotenv from 'dotenv';
 
 dotenv.config();
 
+const KEEP_ALIVE_TIMEOUT = process.env.KEEP_ALIVE_TIMEOUT;
+
 /**
  * Handles serving the API through the express framework.
  */
@@ -74,6 +76,9 @@ export class ExpressDriver {
      * Create HTTP server.
      */
     const server = http.createServer(this.app);
+    server.keepAliveTimeout = KEEP_ALIVE_TIMEOUT
+      ? parseInt(KEEP_ALIVE_TIMEOUT, 10)
+      : server.keepAliveTimeout;
 
     let io = socketio(server, { pingInterval: 2000, pingTimeout: 5000 });
     let socketInteractor = SocketInteractor.init(io);


### PR DESCRIPTION
**Purpose of this PR**
This PR is in response to service failures causing 502 Bad Gateway and 504 Gateway Timeout errors. In attempt to fix this issue based on a suggestion in [this](https://adamcrowder.net/posts/node-express-api-and-aws-alb-502/) article, this PR allows the service's server's keep alive timeout widow to be configured.

**Changes in this PR**
- Allows Express server's keep alive time out to be configured by an env variable