### PR TITLE
Fix route collision breaking User Service functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -395,15 +395,6 @@ export default class ExpressRouteDriver {
   private buildUserRouter() {
     let router: Router = express.Router();
 
-    router.get(
-      '/:username',
-      proxy(USERS_API, {
-        proxyReqPathResolver: req => {
-          return USER_ROUTES.FETCH_USER(req.params.username);
-        },
-      }),
-    );
-
     router.post(
       '/:userId/learning-objects/:learningObjectId/changelog',
       proxy(LEARNING_OBJECT_SERVICE_URI, {
@@ -688,6 +679,15 @@ export default class ExpressRouteDriver {
       proxy(USERS_API, {
         proxyReqPathResolver: req => {
           return ADMIN_USER_ROUTES.FETCH_USER_ROLES(req.params.id);
+        },
+      }),
+    );
+
+    router.get(
+      '/:username',
+      proxy(USERS_API, {
+        proxyReqPathResolver: req => {
+          return USER_ROUTES.FETCH_USER(req.params.username);
         },
       }),
     );


### PR DESCRIPTION
**Purpose of this PR**
Fix route collision causing routes to be proxied to the incorrect resources.

**Changes in this PR**
- Moves `/users/:username` to bottom of route tree to prevent collision