### PR TITLE
Fix bug where route to proxy metrics doesn't include the route params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.17.0-1",
+  "version": "2.17.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.17.0-1",
+  "version": "2.17.1",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -182,7 +182,7 @@ export default class ExpressRouteDriver {
       '/users/:username/learning-objects/:id/metrics',
       proxy(CART_API, {
         proxyReqPathResolver: req => {
-          return `/users/:username/learning-objects/:id/metrics`;
+          return `/users/${encodeURIComponent(req.params.username)}/learning-objects/${encodeURIComponent(req.params.id)}/metrics`;
         },
       }),
     );


### PR DESCRIPTION
Fixes a bug where some goof (me) forgot to include the route params in the proxy for the metrics