### PR TITLE
Update download route to use cuid and version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -222,7 +222,11 @@ export default class ExpressRouteDriver {
 
     router.get('/users/:username/learning-objects/:id', proxy(LEARNING_OBJECT_SERVICE_URI, {
       proxyReqPathResolver: req => {
-        return `/users/${encodeURIComponent(req.params.username)}/learning-objects/${encodeURIComponent(req.params.id)}`;
+        let uri = `/users/${encodeURIComponent(req.params.username)}/learning-objects/${encodeURIComponent(req.params.id)}`;
+        if (req.query) {
+          uri += '?' + querystring.stringify(req.query);
+        }
+        return uri;
       },
     }));
 

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -694,14 +694,16 @@ export default class ExpressRouteDriver {
         }),
       );
 
-    router.route('/:username/learning-objects/:learningObjectName/bundle').get(
+    router.route('/:username/learning-objects/:cuid/versions/:version/bundle').get(
       proxy(LEARNING_OBJECT_SERVICE_URI, {
         proxyReqPathResolver: req => {
           return `/users/${encodeURIComponent(
             req.params.username,
           )}/learning-objects/${encodeURIComponent(
-            req.params.learningObjectName,
-          )}/bundle?${querystring.stringify(req.query)}`;
+            req.params.cuid,
+          )}/versions/${encodeURIComponent(
+            req.params.version,
+          )}bundle`;
         },
       }),
     );

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -220,15 +220,16 @@ export default class ExpressRouteDriver {
       }),
     );
 
-    router.get('/users/:username/learning-objects/:id', proxy(LEARNING_OBJECT_SERVICE_URI, {
-      proxyReqPathResolver: req => {
-        let uri = `/users/${encodeURIComponent(req.params.username)}/learning-objects/${encodeURIComponent(req.params.id)}`;
-        if (req.query) {
-          uri += '?' + querystring.stringify(req.query);
-        }
-        return uri;
-      },
-    }));
+    router.route('/users/:username/learning-objects/:id')
+      .all(proxy(LEARNING_OBJECT_SERVICE_URI, {
+        proxyReqPathResolver: req => {
+          let uri = `/users/${encodeURIComponent(req.params.username)}/learning-objects/${encodeURIComponent(req.params.id)}`;
+          if (req.query) {
+            uri += '?' + querystring.stringify(req.query);
+          }
+          return uri;
+        },
+      }));
 
     // Retrieves the metrics for a learning object
     router.get(
@@ -703,6 +704,16 @@ export default class ExpressRouteDriver {
           },
         }),
       );
+
+    router.post('/:username/learning-objects/:cuid/versions', proxy(LEARNING_OBJECT_SERVICE_URI, {
+      proxyReqPathResolver: req => {
+        return `/users/${encodeURIComponent(
+          req.params.username,
+        )}/learning-objects/${encodeURIComponent(
+          req.params.cuid,
+        )}/versions`;
+      },
+    }));
 
     router.route('/:username/learning-objects/:cuid/versions/:version/bundle').get(
       proxy(LEARNING_OBJECT_SERVICE_URI, {

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -220,6 +220,12 @@ export default class ExpressRouteDriver {
       }),
     );
 
+    router.get('/users/:username/learning-objects/:id', proxy(LEARNING_OBJECT_SERVICE_URI, {
+      proxyReqPathResolver: req => {
+        return `/users/${encodeURIComponent(req.params.username)}/learning-objects/${encodeURIComponent(req.params.id)}`;
+      },
+    }));
+
     // Retrieves the metrics for a learning object
     router.get(
       '/users/:username/learning-objects/:id/metrics',

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -212,10 +212,10 @@ export default class ExpressRouteDriver {
       );
 
     router.get(
-      '/library/stats',
+      '/learning-objects/metrics',
       proxy(CART_API, {
         proxyReqPathResolver: req => {
-          return `/library/stats`;
+          return `/learning-objects/metrics`;
         },
       }),
     );
@@ -233,10 +233,10 @@ export default class ExpressRouteDriver {
 
     // Retrieves the metrics for a learning object
     router.get(
-      '/users/:username/learning-objects/:id/metrics',
+      '/users/:username/learning-objects/:cuid/metrics',
       proxy(CART_API, {
         proxyReqPathResolver: req => {
-          return `/users/${encodeURIComponent(req.params.username)}/learning-objects/${encodeURIComponent(req.params.id)}/metrics`;
+          return `/users/${encodeURIComponent(req.params.username)}/learning-objects/${encodeURIComponent(req.params.cuid)}/metrics`;
         },
       }),
     );
@@ -398,15 +398,6 @@ export default class ExpressRouteDriver {
         },
       }),
     );
-
-    router.get(
-      '/count/:author',
-      proxy(CART_API, {
-        proxyReqPathResolver: req => {
-          return `/count/${encodeURIComponent(req.params.author)}`;
-        },
-      }),
-    );
     // get the status for the banner
     router.get(
       '/status',
@@ -425,7 +416,7 @@ export default class ExpressRouteDriver {
         },
       }),
     );
-    // get the client version to see if there is an updated
+    // get the client version to see if there is an update
     router.get(
       '/clientversion/:clientVersion',
       proxy(UTILITY_API, {
@@ -477,34 +468,23 @@ export default class ExpressRouteDriver {
     let router: Router = express.Router();
 
     router.post(
-      '/:userId/learning-objects/:learningObjectId/changelog',
+      '/:userId/learning-objects/:cuid/changelog',
       proxy(LEARNING_OBJECT_SERVICE_URI, {
         proxyReqPathResolver: req => {
           return LEARNING_OBJECT_ROUTES.CREATE_CHANGELOG(
             req.params.userId,
-            req.params.learningObjectId,
+            req.params.cuid,
           );
         },
       }),
     );
     router.get(
-      '/:userId/learning-objects/:learningObjectId/changelog',
-      proxy(LEARNING_OBJECT_SERVICE_URI, {
-        proxyReqPathResolver: req => {
-          return LEARNING_OBJECT_ROUTES.GET_RECENT_CHANGELOG(
-            req.params.userId,
-            req.params.learningObjectId,
-          );
-        },
-      }),
-    );
-    router.get(
-      '/:userId/learning-objects/:learningObjectId/changelogs',
+      '/:userId/learning-objects/:cuid/changelogs',
       proxy(LEARNING_OBJECT_SERVICE_URI, {
         proxyReqPathResolver: req => {
           return LEARNING_OBJECT_ROUTES.GET_ALL_CHANGELOGS(
             req.params.userId,
-            req.params.learningObjectId,
+            req.params.cuid,
             req.query,
           );
         },
@@ -656,54 +636,33 @@ export default class ExpressRouteDriver {
         },
       }),
     );
-    router
-      .route('/:username/cart')
-      .get(
-        proxy(CART_API, {
-          // get cart
-          proxyReqPathResolver: req => {
-            return req.query.download
-              ? `/users/${encodeURIComponent(
-                req.params.username,
-              )}/cart?download=true`
-              : `/users/${encodeURIComponent(req.params.username)}/cart`;
-          },
-        }),
-      )
-      .delete(
-        proxy(CART_API, {
-          // clear cart
-          proxyReqPathResolver: req => {
-            return `/users/${encodeURIComponent(req.params.username)}/cart`;
-          },
-        }),
-      );
-    router
-      .route('/:username/cart/learning-objects/:author/:learningObjectName')
-      .post(
-        proxy(CART_API, {
-          // add learning object to cart
-          proxyReqPathResolver: req => {
-            return `/users/${encodeURIComponent(
-              req.params.username,
-            )}/cart/learning-objects/${encodeURIComponent(
-              req.params.author,
-            )}/${encodeURIComponent(req.params.learningObjectName)}`;
-          },
-        }),
-      )
-      .delete(
-        proxy(CART_API, {
-          // remove learning object from cart
-          proxyReqPathResolver: req => {
-            return `/users/${encodeURIComponent(
-              req.params.username,
-            )}/cart/learning-objects/${req.params.author}/${encodeURIComponent(
-              req.params.learningObjectName,
-            )}`;
-          },
-        }),
-      );
+    router.get(
+      '/:username/library/learning-objects',
+      proxy(CART_API, {
+        // get library
+        proxyReqPathResolver: req => {
+          return `/users/${encodeURIComponent(req.params.username)}/library/learning-objects`;
+        },
+      }),
+    );
+    router.delete(
+      '/:username/library/learning-objects/:cuid',
+      proxy(CART_API, {
+        // Delete a learning object from the users library
+        proxyReqPathResolver: req => {
+          return `/users/${encodeURIComponent(req.params.username)}/library/learning-objects/${encodeURIComponent(req.params.cuid)}`;
+        },
+      }),
+    );
+    router.post(
+      '/:username/library/learning-objects',
+      proxy(CART_API, {
+        // Add a learning object to the users library
+        proxyReqPathResolver: req => {
+          return `/users/${encodeURIComponent(req.params.username)}/library/learning-objects`;
+        },
+      }),
+    );
 
     router.post('/:username/learning-objects/:cuid/versions', proxy(LEARNING_OBJECT_SERVICE_URI, {
       proxyReqPathResolver: req => {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -123,21 +123,21 @@ export const LEARNING_OBJECT_ROUTES = {
   UPDATE_PDF(id: string) {
     return `/learning-objects/${id}/pdf`;
   },
-  CREATE_CHANGELOG(userId: string, learningObjectId: string) {
+  CREATE_CHANGELOG(userId: string, cuid: string) {
     return `/users/${encodeURIComponent(
       userId,
-    )}/learning-objects/${encodeURIComponent(learningObjectId)}/changelog`;
+    )}/learning-objects/${encodeURIComponent(cuid)}/changelog`;
   },
   GET_RECENT_CHANGELOG(userId: string, learningObjectId: string) {
     return `/users/${encodeURIComponent(
       userId,
     )}/learning-objects/${encodeURIComponent(learningObjectId)}/changelog`;
   },
-  GET_ALL_CHANGELOGS(userId: string, learningObjectId: string, query: any) {
+  GET_ALL_CHANGELOGS(userId: string, cuid: string, query: any) {
     return `/users/${encodeURIComponent(
       userId,
     )}/learning-objects/${encodeURIComponent(
-      learningObjectId,
+      cuid,
     )}/changelogs?${querystring.stringify(query)}`;
   },
   DOWNLOAD_FILE(params: {


### PR DESCRIPTION
***Purpose***
This PR restructures the `/bundle` route to `/users/:username/learning-objects/:cuid/versions/:version/bundle`.