### PR TITLE
Update Library Service Proxies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -641,7 +641,7 @@ export default class ExpressRouteDriver {
       proxy(CART_API, {
         // get library
         proxyReqPathResolver: req => {
-          return `/users/${encodeURIComponent(req.params.username)}/library/learning-objects`;
+          return `/users/${encodeURIComponent(req.params.username)}/library/learning-objects?${querystring.stringify(req.query)}`;
         },
       }),
     );
@@ -650,7 +650,7 @@ export default class ExpressRouteDriver {
       proxy(CART_API, {
         // Delete a learning object from the users library
         proxyReqPathResolver: req => {
-          return `/users/${encodeURIComponent(req.params.username)}/library/learning-objects/${encodeURIComponent(req.params.cuid)}`;
+          return `/users/${encodeURIComponent(req.params.username)}/library/learning-objects/${encodeURIComponent(req.params.cuid)}?${querystring.stringify(req.query)}`;
         },
       }),
     );


### PR DESCRIPTION
***Purpose***
This PR extends the proxy routes for reading and deleting Library Items in order to allow query strings to pass through.

***Related***
This PR directly relates to https://github.com/Cyber4All/library-service/pull/150