### PR TITLE
Davidns/ch2142/add a gateway proxy for change learning object

### DIFF
--- a/src/drivers/express/ExpressAdminRouteDriver.ts
+++ b/src/drivers/express/ExpressAdminRouteDriver.ts
@@ -7,11 +7,23 @@ import {
   ADMIN_LEARNING_OBJECT_ROUTES,
   ADMIN_USER_ROUTES,
   ADMIN_MAILER_ROUTES,
+  ADMIN_LAMBDA_ROUTES,
 } from '../../routes';
 
 const USERS_API = process.env.USERS_API || 'localhost:4000';
 const LEARNING_OBJECT_SERVICE_URI =
   process.env.LEARNING_OBJECT_SERVICE_URI || 'localhost:5000';
+
+
+/**
+ * Lambda gateways
+ *
+ * Lambda introduces a new level of complexity since the base route
+ * changes depending on the lambda function when seperate endpoints are introduced.
+ * In the future it would be wise to group our lambda functions under one resource.
+ */
+const COA_API = process.env.COA_LAMBDA || 'localhost:4001';
+
 
 /**
  * Serves as a factory for producing a router for the express app.rt
@@ -203,5 +215,17 @@ export default class ExpressAdminRouteDriver {
           },
         }),
       );
+
+
+  // Lambda routes
+    router.post(
+      '/change-author',
+      proxy(COA_API, {
+      proxyReqPathResolver: req => {
+        const route = ADMIN_LAMBDA_ROUTES.CHANGE_AUTHOR;
+        return route;
+      },
+    }));
   }
+
 }

--- a/src/drivers/express/ExpressAdminRouteDriver.ts
+++ b/src/drivers/express/ExpressAdminRouteDriver.ts
@@ -219,7 +219,7 @@ export default class ExpressAdminRouteDriver {
 
   // Lambda routes
     router.post(
-      '/change-author',
+      '/users/:username/learning-object/:cuid/change-author',
       proxy(COA_API, {
       proxyReqPathResolver: req => {
         const route = ADMIN_LAMBDA_ROUTES.CHANGE_AUTHOR;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -308,3 +308,7 @@ export const UTILITY_ROUTES = {
   MAINTENANCE: '/maintenance',
   STATUS: '/status',
 };
+
+export const ADMIN_LAMBDA_ROUTES = { 
+  CHANGE_AUTHOR: '/dev/src/handler.changeObjectAuthro',
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -310,5 +310,5 @@ export const UTILITY_ROUTES = {
 };
 
 export const ADMIN_LAMBDA_ROUTES = { 
-  CHANGE_AUTHOR: '/dev/src/handler.changeObjectAuthro',
+  CHANGE_AUTHOR: '/dev/src/handler.changeObjectAuthor',
 }


### PR DESCRIPTION
This PR adds a gateway proxy for the Change authorship functionality.
The Gateway production env will need to be updated with the base endpoint for the lambda