### PR TITLE
Add the route to jwt.config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -72,6 +72,14 @@ export default class ExpressRouteDriver {
         },
       }),
     );
+    router.get(
+      '/outcomes/stats',
+      proxy(OUTCOME_API, {
+        proxyReqPathResolver: req => {
+          return STATS_ROUTE.OUTCOME_STATS;
+        },
+      }),
+    );
 
     // GUIDELINE ROLES
     router.route('/guidelines/members').get(
@@ -567,14 +575,6 @@ export default class ExpressRouteDriver {
           return `/users/${encodeURIComponent(req.params.username)}/learning-objects/${encodeURIComponent(
             req.params.learningObjectId,
           )}/outcomes/${encodeURIComponent(req.params.outcomeId)}/mappings/${encodeURIComponent(req.params.mappingId)}`;
-        },
-      }),
-    );
-    router.get(
-      '/outcomes/stats',
-      proxy(OUTCOME_API, {
-        proxyReqPathResolver: req => {
-          return `/outcomes/stats`;
         },
       }),
     );

--- a/src/drivers/middleware/jwt.config.ts
+++ b/src/drivers/middleware/jwt.config.ts
@@ -38,6 +38,7 @@ export const enforceTokenAccess = jwt({
     '/outages',
     /\/users\/[0-z,.,-]+\/cards/i,
     '/library/stats',
+    '/outcomes/stats',
   ],
 }); // register // all ota-code routes do their own verification outsides of JWT // login
 // TODO: Whitelist user routes

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -301,6 +301,7 @@ export const ADMIN_MAILER_ROUTES = {
 
 export const STATS_ROUTE = {
   USER_STATS: '/users/stats',
+  OUTCOME_STATS: '/outcomes/stats',
   LEARNING_OBJECT_STATS: '/learning-objects/stats',
 };
 


### PR DESCRIPTION
This PR adds the outcomes/stats route to the jwt.config so it will not be piped through to check for a valid token. What appeared to be route collision was actually an extra request from the client. 