### PR TITLE
Update the route for change authorship

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.26.4",
+  "version": "2.26.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "2.26.4",
+  "version": "2.26.5",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/express/ExpressAdminRouteDriver.ts
+++ b/src/drivers/express/ExpressAdminRouteDriver.ts
@@ -7,22 +7,11 @@ import {
   ADMIN_LEARNING_OBJECT_ROUTES,
   ADMIN_USER_ROUTES,
   ADMIN_MAILER_ROUTES,
-  ADMIN_LAMBDA_ROUTES,
 } from '../../routes';
 
 const USERS_API = process.env.USERS_API || 'localhost:4000';
 const LEARNING_OBJECT_SERVICE_URI =
   process.env.LEARNING_OBJECT_SERVICE_URI || 'localhost:5000';
-
-
-/**
- * Lambda gateways
- *
- * Lambda introduces a new level of complexity since the base route
- * changes depending on the lambda function when seperate endpoints are introduced.
- * In the future it would be wise to group our lambda functions under one resource.
- */
-const COA_API = process.env.COA_LAMBDA || 'localhost:5001';
 
 
 /**
@@ -215,18 +204,6 @@ export default class ExpressAdminRouteDriver {
           },
         }),
       );
-
-
-  // Lambda routes
-    router.post(
-      '/users/:username/learning-objects/:cuid/change-author',
-      proxy(COA_API, {
-      proxyReqPathResolver: req => {
-        const route = ADMIN_LAMBDA_ROUTES.CHANGE_AUTHOR;
-        console.log(route);
-        return route;
-      },
-    }));
   }
 
 }

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -79,7 +79,6 @@ export default class ExpressRouteDriver {
     router.route('/users/:userId/learning-objects/:learningObjectId/change-author').post(
       proxy(COA_API, {
         proxyReqPathResolver: req => {
-        console.log('nopers');
         const userId = req.params.userId;
         const learningObjectId = req.params.learningObjectId;
         const route = ADMIN_LAMBDA_ROUTES.CHANGE_AUTHOR(userId, learningObjectId);

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -12,6 +12,7 @@ import {
   ADMIN_USER_ROUTES,
   USER_ROUTES,
   UTILITY_ROUTES,
+  ADMIN_LAMBDA_ROUTES,
 } from '../../routes';
 import { SocketInteractor } from '../../interactors/SocketInteractor';
 
@@ -26,6 +27,7 @@ const UTILITY_API = process.env.UTILITY_URI || 'localhost:9000';
 const NOTIFICATION_API = process.env.NOTIFICATION_API || 'localhost:8000';
 const OUTCOME_API = process.env.OUTCOME_API || 'localhost:3000';
 const FEATURED_API = process.env.FEATURED_API || 'localhost:3002';
+const COA_API = process.env.COA_SERVICE || 'localhost:8500';
 
 /**
  * Serves as a factory for producing a router for the express app.rt
@@ -71,6 +73,19 @@ export default class ExpressRouteDriver {
           return `/featured/learning-objects`;
         },
       }),
+    );
+
+     // Lambda routes
+    router.route('/users/:userId/learning-objects/:learningObjectId/change-author').post(
+      proxy(COA_API, {
+        proxyReqPathResolver: req => {
+        console.log('nopers');
+        const userId = req.params.userId;
+        const learningObjectId = req.params.learningObjectId;
+        const route = ADMIN_LAMBDA_ROUTES.CHANGE_AUTHOR(userId, learningObjectId);
+        return route;
+        },
+      })
     );
 
     // Retrieves the metrics for a collection

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -84,7 +84,7 @@ export default class ExpressRouteDriver {
         const route = ADMIN_LAMBDA_ROUTES.CHANGE_AUTHOR(userId, learningObjectId);
         return route;
         },
-      })
+      }),
     );
 
     // Retrieves the metrics for a collection

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -314,5 +314,9 @@ export const UTILITY_ROUTES = {
 };
 
 export const ADMIN_LAMBDA_ROUTES = { 
-  CHANGE_AUTHOR: '/dev/changeObjectAuthorHandler',
+  CHANGE_AUTHOR(userId: string, learningObjectId: string) {
+    return `/users/${encodeURIComponent(
+      userId,
+    )}/learning-objects/${encodeURIComponent(learningObjectId)}/change-author`;
+  },
 }


### PR DESCRIPTION
This updates the route to point to localhost:8500 for local development. 

The environment variable will need to updated in AWS once this is deployed. Environment variable is COA_SERVICE. 

Note: I moved this route from the admin express driver because we have not used that in quite some time and the jwt.config lists the routes that are public. 