### PR TITLE
4060/determine-why-gateway-deployment-is-failing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,11 +40,8 @@ jobs:
           name: Zip dist
           command: zip -r dist.zip . *
       - run:
-          name: Show Content
-          command: ls
-      # - run:
-      #     name: Deploy to Elastic Beanstalk 
-      #     command: eb deploy Gateway-API --verbose --label Gateway-API-v$(node -p "require('./package.json').version")
+          name: Deploy to Elastic Beanstalk 
+          command: eb deploy Gateway-API --verbose --label Gateway-API-v$(node -p "require('./package.json').version")
 workflows:
   version: 2
   build:

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm run start:prod
+web: npm run serve:prod

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark-gateway",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark-gateway",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
         "@sentry/node": "^5.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
This PR fixes the circle ci config to package production dependencies and the docs folder.  Completes story [4060/determine-why-gateway-deployment-is-failing](https://app.clubhouse.io/clarkcan/story/4060/determine-why-gateway-deployment-is-failing).