### PR TITLE
Add query to guidelines route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/modules/standard-guidelines/search-module/SearchController.ts
+++ b/src/modules/standard-guidelines/search-module/SearchController.ts
@@ -67,7 +67,7 @@ export class SearchController implements Controller {
          *            schema:
          *              $ref: '#/components/schemas/FrameworkSearchResults'
          */
-        router.get('/frameworks', this.proxyRequest((req: Request) => `/frameworks`));
+        router.get('/frameworks', this.proxyRequest((req: Request) => `/frameworks?${req.query ? querystring.stringify(req.query) : ''}`));
 
         /**
          * @swagger


### PR DESCRIPTION
This PR adds a query string so that the page and limit and any other parameter is properly passed to the standard-guidelines service. 