### PR TITLE
Add fix to the version #

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/modules/learning-object-service/revisions/RevisionsController.ts
+++ b/src/modules/learning-object-service/revisions/RevisionsController.ts
@@ -128,7 +128,7 @@ export class RevisionsController implements Controller {
      *      404:
      *        description: NOT FOUND - Learning object not found or Learning Object revision not found
      */
-      router.delete('/users/:username/learning-objects/:cuid/versions', this.proxyRequest((req: Request) => `/users/${encodeURIComponent(req.params.username)}/learning-objects/${encodeURIComponent(req.params.cuid)}/versions`));
+      router.delete('/users/:username/learning-objects/:cuid/versions/:version', this.proxyRequest((req: Request) => `/users/${encodeURIComponent(req.params.username)}/learning-objects/${encodeURIComponent(req.params.cuid)}/versions/${encodeURIComponent(req.params.version)}`));
     
       return router;
   }


### PR DESCRIPTION
This PR adds an extension to the delete revision route that was put in last week. The version needed to be added so there were less round trips to the database in learning-object-service. 