### PR TITLE
Fix query to text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark-gateway",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "packages": {
     "": {
       "name": "clark-gateway",
-      "version": "3.5.4",
+      "version": "3.5.5",
       "license": "ISC",
       "dependencies": {
         "@sentry/node": "^5.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/modules/learning-object-service/objects/ObjectsController.ts
+++ b/src/modules/learning-object-service/objects/ObjectsController.ts
@@ -342,7 +342,7 @@ export class ObjectsController implements Controller {
      *        required: true
      *        description: The object return limit
      *      - in: query
-     *        name: query
+     *        name: text
      *        schema:
      *          type: string
      *        required: true


### PR DESCRIPTION
This PR updates the swagger doc in the LO search route to be text instead of query. 