### PR TITLE
/google and /google/redirect don't need auth

### DIFF
--- a/src/drivers/middleware/jwt.config.ts
+++ b/src/drivers/middleware/jwt.config.ts
@@ -52,6 +52,8 @@ export const enforceTokenAccess = jwt({
     "/frameworks",
     "/topics",
     "/favicon.ico",
+    "/google",
+    "/google/redirect"
   ],
 }); // register // all ota-code routes do their own verification outsides of JWT // login
 // TODO: Whitelist user routes


### PR DESCRIPTION
this PR completes [11679](https://app.shortcut.com/clarkcan/story/11679/add-google-and-google-redirect-to-routes-that-do-not-require-authorization-in-clark-gateway)
- adds /google and /google/redirect to the list of routes that don't require authorization