### PR TITLE
Add route for hierarchy object creation

### DIFF
--- a/src/modules/learning-object-service/objects/ObjectsController.ts
+++ b/src/modules/learning-object-service/objects/ObjectsController.ts
@@ -244,9 +244,9 @@ export class ObjectsController implements Controller {
      *              length:
      *                type: string
      *                description: The length of the learning object
-     *              status:
+     *              collection:
      *                type: string
-     *                description: The desired status of the learning object
+     *                description: The collection the learning object needs to be added to
      *    responses:
      *      200:
      *        description: OK

--- a/src/modules/learning-object-service/objects/ObjectsController.ts
+++ b/src/modules/learning-object-service/objects/ObjectsController.ts
@@ -216,6 +216,49 @@ export class ObjectsController implements Controller {
      */
     router.post("/learning-objects/:username/:learningObjectName/children", this.proxyRequest((req: Request) => `/learning-objects/${req.params.username}/${req.params.learningObjectName}/children`));
 
+
+        /**
+     * @swagger
+     * /learning-objects/{username}/hierarchy-object:
+     *  post:
+     *    description: Creates a learning object for a hierarchy
+     *    tags:
+     *      - Learning Object Service
+     *    parameters:
+     *      - in: path
+     *        name: username
+     *        schema:
+     *          type: string
+     *        required: true
+     *        description: The object author's username
+     *
+     *    requestBody:
+     *      content:
+     *        application/json:
+     *          schema:
+     *            type: object
+     *            properties:
+     *              name:
+     *                type: string
+     *                description: The name of the learning object
+     *              length:
+     *                type: string
+     *                description: The length of the learning object
+     *              status:
+     *                type: string
+     *                description: The desired status of the learning object
+     *    responses:
+     *      200:
+     *        description: OK
+     *      400:
+     *        description: BAD_REQUEST - Object name is not more than 2 characters, length is not valid, or status is not valid
+     *      401:
+     *        description: UNAUTHENTICATED - User not logged in
+     *      403:
+     *        description: UNAUTHORIZED - User not object author, admin, or editor
+     */
+    router.post("/users/:username/hierarchy-object", this.proxyRequest((req: Request) => `/users/${req.params.username}/hierarchy-object`));
+
     /**
      * @swagger
      * /learning-objects/{username}/{learningObjectName}/children:

--- a/src/modules/learning-object-service/objects/ObjectsController.ts
+++ b/src/modules/learning-object-service/objects/ObjectsController.ts
@@ -247,6 +247,9 @@ export class ObjectsController implements Controller {
      *              collection:
      *                type: string
      *                description: The collection the learning object needs to be added to
+     *              contributors:
+     *                type: string
+     *                description: The ids of the contributors of the learning object
      *    responses:
      *      200:
      *        description: OK


### PR DESCRIPTION
This PR adds the proxy for the new route in the learning object service that will allow for admins and editors to create new learning objects to be children of a learning object. 