### PR TITLE
Backend for Blog Posts

### DIFF
--- a/src/drivers/middleware/jwt.config.ts
+++ b/src/drivers/middleware/jwt.config.ts
@@ -53,7 +53,8 @@ export const enforceTokenAccess = jwt({
     "/topics",
     "/favicon.ico",
     "/google",
-    "/google/redirect"
+    "/google/redirect",
+    "/blogs"
   ],
 }); // register // all ota-code routes do their own verification outsides of JWT // login
 // TODO: Whitelist user routes

--- a/src/modules/utility-service/Components.ts
+++ b/src/modules/utility-service/Components.ts
@@ -17,7 +17,7 @@
  *              properties:
  *                  _id:
  *                      type: ObjectId
- *                      description: identifer used my mongo to find document
+ *                      description: identifer used by mongo to find document
  *                      example: ObjectId()
  *                      required: true
  *                  name:
@@ -53,7 +53,33 @@
  *                      description: timestamp of when outage occured
  *                      example: 2020-02-19T20:45:38.335+00:00
  *                      required: true
+ *          Blog:
+ *              properties:
+ *                  _id:
+ *                      type: ObjectId
+ *                      description: identifier used by mongo to find document
+ *                      example: ObjectId()
+ *                      required: true
+ *                  name:
+ *                      type: string
+ *                      description: name of blog
+ *                      example: CLARK and CARD SSO
+ *                      required: true
+ *                  description:
+ *                      type: string
+ *                      description: description of blog
+ *                      example: CLARK and CARD Single-Sign-On has now been deployed and ready for use!
+ *                      required: true
+ *                  timestamp:
+ *                      type: Date
+ *                      description: the publish date of the blog
+ *                      example: 2022-09-07T00:00:00.000+00:00
+ *                      required: true
+ *                  url:
+ *                      type: string
+ *                      description: the URL of the blog
+ *                      example: N/A
+ *                      required: true
  * 
- *                  
- *          
+ * 
  */

--- a/src/modules/utility-service/UtilityServiceController.ts
+++ b/src/modules/utility-service/UtilityServiceController.ts
@@ -110,6 +110,36 @@ export class UtilityServiceController implements Controller {
             "/outages",
             this.proxyRequest((req: Request) => `/outages?pastIssues=${encodeURIComponent(req.query.pastIssues as string)}`)
         );
+
+        /**
+         * @swagger
+         * /blogs:
+         *  get:
+         *      description: Gets the blogs to display to the user
+         *      tags:
+         *          - Utility Service
+         *      parameters:
+         *          - in: query
+         *            name: recent
+         *            schema:
+         *              type: boolean
+         *            required: false
+         *            description: Whether the most recent blog should be returned or all blogs should be returned
+         *      responses:
+         *          200:
+         *              description: OK - Returns array of blog(s)
+         *              content:
+         *                  application/json:
+         *                      type: array
+         *                      items:
+         *                          $ref: '#/components/schemas/Blog'
+         *          500:
+         *              description: INTERNAL - Unable to get blogs
+         */
+        router.get(
+            "/blogs",
+            this.proxyRequest((req: Request) => `/blogs?recent=${encodeURIComponent(req.query.recent as string)}`)
+        )
         return router;
     }
 


### PR DESCRIPTION
Partially completes story [8447](https://app.shortcut.com/clarkcan/story/8447/backend-for-blog-posts).

In this PR:
- A route has been added for blogs in utility-service
- Swagger docs added for blogs route

Note: Since the 'recent' query has been passed as a string, the route in utility service will also read the query as a string instead of a boolean.