### PR TITLE
Feature/sc 18779/fix banner on clark to work with secured

### DIFF
--- a/.default.env
+++ b/.default.env
@@ -63,3 +63,6 @@ USERS_API=
 ## utility-service api uri
 ## default: localhost:9000
 UTILITY_URI=
+
+## secured-downtime-service uri
+DOWNTIME_LAMBDA_URI=

--- a/src/drivers/middleware/jwt.config.ts
+++ b/src/drivers/middleware/jwt.config.ts
@@ -54,7 +54,8 @@ export const enforceTokenAccess = jwt({
     "/favicon.ico",
     "/google",
     "/google/redirect",
-    "/blogs"
+    "/blogs",
+    "/downtime"
   ],
 }); // register // all ota-code routes do their own verification outsides of JWT // login
 // TODO: Whitelist user routes

--- a/src/modules/utility-service/Components.ts
+++ b/src/modules/utility-service/Components.ts
@@ -2,17 +2,13 @@
  * @swagger
  * components:
  *      schemas:
- *          Status:
- *              properties:
- *                  isUnderMaintenance:
- *                      type: boolean
- *                      description: a boolean that denotes the status for the banner
- *                      example: true
- *                      required: true
- *                  message:
- *                      type: string
- *                      example: Clark is now accepting curriculum submissions to the Plan C collection.
- *                      required: true
+ *          Downtime:
+ *             properties:
+ *                  isDown:
+ *                     type: boolean
+ *                     description: a boolean that denotes the status for the downtime
+ *                     example: true
+ *                     required: true
  *          Outage:
  *              properties:
  *                  _id:

--- a/src/modules/utility-service/UtilityServiceController.ts
+++ b/src/modules/utility-service/UtilityServiceController.ts
@@ -29,7 +29,7 @@ export class UtilityServiceController implements Controller {
          */
         router.get(
             "/downtime",
-            this.proxyRequestToLambda((req: Request) => "/downtime")
+            this.proxyRequestToLambda((req: Request) => `/downtime?service=${encodeURIComponent(req.query.service as string)}`)
         );
 
          /**

--- a/src/modules/utility-service/UtilityServiceController.ts
+++ b/src/modules/utility-service/UtilityServiceController.ts
@@ -6,47 +6,30 @@ import { Request } from "express";
 import { Controller } from "../../interfaces/Controller";
 
 const UTILITY_API = process.env.UTILITY_URI || "localhost:9000";
+const DOWNTIME_LAMBDA = process.env.DOWNTIME_LAMBDA_URI;
 
 export class UtilityServiceController implements Controller {
     buildRouter(): Router {
         const router = Router();
-        
-        /**
-         * @swagger
-         * /status:
-         *  get:
-         *      description: Gets the status for the banner
-         *      tags:
-         *          - Utility Service
-         *      responses:
-         *          200:
-         *              description: OK - Returns status report
-         *              content:
-         *                  application/json:
-         *                          schema:
-         *                              $ref: '#/components/schemas/Status'
-         */
-        router.get(
-            "/status",
-            this.proxyRequest((req: Request) => "/status")
-        );
 
         /**
          * @swagger
-         * /maintenance:
+         * /downtime:
          *  get:
-         *      description: Gets the maintenance status for maintenance page
-         *      tags:
-         *          - Utility Service
-         *      responses:
-         *          200:
-         *              description: OK - Returns the maintenance status as a boolean from the mongodb downtime collection
-         *                      
-         *                  
+         *     description: Gets the downtime status for clark
+         *     tags:
+         *        - Secured Downtime Service
+         *     responses:
+         *       200:
+         *        description: OK - Returns the downtime status as an object with message and isDown
+         *        content:
+         *          application/json:
+         *              schema:
+         *                  $ref: '#/components/schemas/Downtime'
          */
         router.get(
-            "/maintenance",
-            this.proxyRequest((req: Request) => "/maintenance")
+            "/downtime",
+            this.proxyRequestToLambda((req: Request) => "/downtime")
         );
 
          /**
@@ -148,6 +131,14 @@ export class UtilityServiceController implements Controller {
             proxyReqPathResolver: req => {
                 return callback(req);
             },
+        });
+    }
+
+    private proxyRequestToLambda(callback: any) {
+        return proxy(DOWNTIME_LAMBDA, {
+            proxyReqPathResolver: req => {
+                return callback(req);
+            }
         });
     }
 }


### PR DESCRIPTION
This PR completes [Fix Banner on CLARK to work with SecurEd Downtime lambda](https://app.shortcut.com/clarkcan/story/18779/fix-banner-on-clark-to-work-with-secured-downtime-lambda) by adding a proxy for the secured downtime service