### PR TITLE
remove user service and utility service uris

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## What this PR does / why we need it
+
+Description
+
+## Which issue(s) this PR fixes (optional)
+
+(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*
+
+Fixes #
+
+## Acceptance Criteria Met
+
+- [ ] Docs changes if needed
+- [ ] Testing changes if needed
+- [ ] All workflow checks passing (automatically enforced)
+- [ ] All review conversations resolved (automatically enforced)
+- [ ] [DCO Sign-off](https://github.com/apps/dco)
+
+**Special notes for your reviewer**:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN npm cache clean --force \
 # Dev Stage
 #
 # Target for docker-compose development environments
-# Requires mounting or volume of ./src to /opt/app/src
 # ----------------------------------------------------------------
 FROM base as dev
 
@@ -34,7 +33,7 @@ RUN npm i -g nodemon \
     && npm i --ignore-scripts --only=development
 
 HEALTHCHECK --start-period=10s --retries=5 --timeout=10s \
-    CMD curl --fail http://localhost:3001 || exit 1   
+    CMD curl --fail http://localhost:3001 || exit 1  
 
 CMD ["dumb-init", "nodemon"]
 

--- a/src/config/env/env.driver.ts
+++ b/src/config/env/env.driver.ts
@@ -13,6 +13,7 @@ import {
     NODE_ENV,
     NOTIFICATIONS_SERVICE_URI,
     PORT,
+    SECURED_DOWNTIME_SERVICE_URI,
     STANDARD_GUIDELINES_SERVICE_URI,
 } from "../global.env";
 import * as dotenv from "dotenv";
@@ -119,6 +120,7 @@ class EnvConfig {
                 NOTIFICATIONS_SERVICE_URI,
                 CLARK_REPORTS_URI,
                 STANDARD_GUIDELINES_SERVICE_URI,
+                SECURED_DOWNTIME_SERVICE_URI,
             ].includes(service)
         ) {
             throw new ServiceError(
@@ -143,6 +145,7 @@ const envConfig = new EnvConfig(process.env).ensureValues([
     NOTIFICATIONS_SERVICE_URI,
     CLARK_REPORTS_URI,
     STANDARD_GUIDELINES_SERVICE_URI,
+    SECURED_DOWNTIME_SERVICE_URI,
 ]);
 
 if (envConfig.isProduction() || envConfig.isStaging()) {

--- a/src/config/env/env.driver.ts
+++ b/src/config/env/env.driver.ts
@@ -14,8 +14,6 @@ import {
     NOTIFICATIONS_SERVICE_URI,
     PORT,
     STANDARD_GUIDELINES_SERVICE_URI,
-    USER_SERVICE_URI,
-    UTILITY_SERVICE_URI,
 } from "../global.env";
 import * as dotenv from "dotenv";
 
@@ -121,8 +119,6 @@ class EnvConfig {
                 NOTIFICATIONS_SERVICE_URI,
                 CLARK_REPORTS_URI,
                 STANDARD_GUIDELINES_SERVICE_URI,
-                USER_SERVICE_URI,
-                UTILITY_SERVICE_URI,
             ].includes(service)
         ) {
             throw new ServiceError(
@@ -147,8 +143,6 @@ const envConfig = new EnvConfig(process.env).ensureValues([
     NOTIFICATIONS_SERVICE_URI,
     CLARK_REPORTS_URI,
     STANDARD_GUIDELINES_SERVICE_URI,
-    USER_SERVICE_URI,
-    UTILITY_SERVICE_URI,
 ]);
 
 if (envConfig.isProduction() || envConfig.isStaging()) {

--- a/src/config/global.env.ts
+++ b/src/config/global.env.ts
@@ -41,16 +41,6 @@ export const CLARK_REPORTS_URI = "CLARK_REPORTS_URI";
 export const STANDARD_GUIDELINES_SERVICE_URI =
     "STANDARD_GUIDELINES_SERVICE_URI";
 
-/**
- * URI target for the user-service
- */
-export const USER_SERVICE_URI = "USER_SERVICE_URI";
-
-/**
- * URI target for the utility-service
- */
-export const UTILITY_SERVICE_URI = "UTILITY_SERVICE_URI";
-
 // ========================================================
 //                        Optional ENVS
 // ========================================================

--- a/src/config/global.env.ts
+++ b/src/config/global.env.ts
@@ -41,6 +41,11 @@ export const CLARK_REPORTS_URI = "CLARK_REPORTS_URI";
 export const STANDARD_GUIDELINES_SERVICE_URI =
     "STANDARD_GUIDELINES_SERVICE_URI";
 
+/**
+ * URI target for the downtime-service
+ */
+export const SECURED_DOWNTIME_SERVICE_URI = "SECURED_DOWNTIME_SERVICE_URI";
+
 // ========================================================
 //                        Optional ENVS
 // ========================================================

--- a/src/modules/clark/user-module/users.routes.ts
+++ b/src/modules/clark/user-module/users.routes.ts
@@ -1,5 +1,3 @@
-import { envConfig } from "../../../config/env/env.driver";
-import { USER_SERVICE_URI } from "../../../config/global.env";
 import { HTTPMethod } from "../../../shared/types/http-method.type";
 import { ProxyRoute } from "../../../shared/types/proxy-route.type";
 
@@ -12,22 +10,14 @@ export const USERS_ROUTES: ProxyRoute[] = [
         method: HTTPMethod.GET,
         path: "/users/:user",
     },
-
-    /**
-     * The following routes have not been declared by
-     * clark-service yet and will have a different target
-     * than clark-service
-     */
     {
         method: HTTPMethod.PATCH,
         path: "/users",
         auth: true,
-        target: envConfig.getUri(USER_SERVICE_URI),
     },
     {
         method: HTTPMethod.GET,
         path: "/users/:username/profile",
         auth: true,
-        target: envConfig.getUri(USER_SERVICE_URI),
     },
 ];

--- a/src/modules/clark/utility-module/utility.routes.ts
+++ b/src/modules/clark/utility-module/utility.routes.ts
@@ -1,5 +1,3 @@
-import { envConfig } from "../../../config/env/env.driver";
-import { UTILITY_SERVICE_URI } from "../../../config/global.env";
 import { HTTPMethod } from "../../../shared/types/http-method.type";
 import { ProxyRoute } from "../../../shared/types/proxy-route.type";
 
@@ -25,16 +23,12 @@ export const UTILITY_ROUTES: ProxyRoute[] = [
         method: HTTPMethod.GET,
         path: "/clientversion",
     },
-
+    
     /**
-     * The following routes have not been declared by
-     * clark-service yet and will have a different target
-     * than clark-service
+     * Downtime Routes
      */
-    // TODO: This routes target should be set for utility service
     {
         method: HTTPMethod.GET,
         path: "/downtime",
-        target: envConfig.getUri(UTILITY_SERVICE_URI),
     },
 ];

--- a/src/modules/clark/utility-module/utility.routes.ts
+++ b/src/modules/clark/utility-module/utility.routes.ts
@@ -1,3 +1,5 @@
+import { envConfig } from "../../../config/env/env.driver";
+import { SECURED_DOWNTIME_SERVICE_URI } from "../../../config/global.env";
 import { HTTPMethod } from "../../../shared/types/http-method.type";
 import { ProxyRoute } from "../../../shared/types/proxy-route.type";
 
@@ -30,5 +32,6 @@ export const UTILITY_ROUTES: ProxyRoute[] = [
     {
         method: HTTPMethod.GET,
         path: "/downtime",
+        target: envConfig.getUri(SECURED_DOWNTIME_SERVICE_URI),
     },
 ];


### PR DESCRIPTION
## What this PR does / why we need it

This PR makes changes that coincide with the changes made to the clark-environments for local development environment.

Notably, the user-service and utility-service URIs are removed from the environment variables because everything should be moved over to the clark-service with exception to the learning object service and services not planned for migration.

## Acceptance Criteria Met

- [x] Docs changes if needed
- [x] Testing changes if needed
- [x] All workflow checks passing (automatically enforced)
- [x] All review conversations resolved (automatically enforced)

**Special notes for your reviewer**:

If someone could double check to make sure the downtime has been moved over. Part of me thinks it /downtime actually looks to the lambda function we use?

- I just checked with @JosueMolinaMorales this is `secured-downtime-service`. The new URI is reflected in the source code.