### PR TITLE
Add patch route for featured collections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "3.7.10",
+  "version": "3.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-gateway",
-  "version": "3.7.10",
+  "version": "3.8.0",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/modules/feature-service/FeatureServiceController.ts
+++ b/src/modules/feature-service/FeatureServiceController.ts
@@ -98,6 +98,38 @@ export class FeatureServiceController implements Controller {
             )}`,
         ),
       );
+
+      /**
+     * @swagger
+     * /featured/learning-objects/:collection:
+     *  patch:
+     *      description: Updates the list of featured learning objects for a collection
+     *      tags:
+     *          - Feature Service
+     *      responses:
+     *          200:
+     *              description: CREATED
+     *              content:
+     *                  application/json:
+     *                      schema:
+     *                          type: array
+     *                          items:
+     *                              $ref: '#/components/schemas/LearningObject'
+     *          400:
+     *              description: BAD REQUEST - At least one of the learning objects is not from the desired featured collection
+     *          404:
+     *              description: NOT FOUND - The desired collection does not exist
+     */
+    router
+    .route("/featured/learning-objects/:collection")
+    .patch(
+      this.proxyRequest(
+        (req: Request) =>
+          `/featured/learning-objects/${encodeURIComponent(
+            req.params.collection,
+          )}`,
+      ),
+    );
     return router;
   }
 


### PR DESCRIPTION
This PR adds the route to update the objects featured in a collection. 

@Cwagne17 yes, I did originally design this to just hit the service and not use Gateway. I promise this is the last weird implementation from the dark times of the early pandemic. 