### PR TITLE
feat: [sc-29046] Implement getting if a learning object has been submitted in clark service

### DIFF
--- a/src/modules/clark/learning-object-module/learning-objects.routes.ts
+++ b/src/modules/clark/learning-object-module/learning-objects.routes.ts
@@ -318,7 +318,9 @@ export const LEARNING_OBJECTS_ROUTES: ProxyRoute[] = [
      */
     {
         method: HTTPMethod.GET,
-        path: "/users/:userId/learning-objects/:learningObjectId/submissions",
+        path: "/learning-objects/:learningObjectId/submissions",
+        target: envConfig.getUri(CLARK_SERVICE_URI),
+        auth: true,
     },
     {
         method: HTTPMethod.POST,


### PR DESCRIPTION
## What this PR does / why we need it
Clark-Gateway changes for implementing getting if a learning object has been submitted in clark service

## Which issue(s) this PR fixes (optional)

Changes the path, target, and auth

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [ ] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
Story details: https://app.shortcut.com/clarkcan/story/29046