### PR TITLE
update target for leraning outcome adds routes

### DIFF
--- a/src/modules/clark/learning-object-module/learning-objects.routes.ts
+++ b/src/modules/clark/learning-object-module/learning-objects.routes.ts
@@ -227,6 +227,7 @@ export const LEARNING_OBJECTS_ROUTES: ProxyRoute[] = [
         method: HTTPMethod.POST,
         path: "/learning-objects/:learningObjectId/learning-outcomes",
         auth: true,
+        target: envConfig.getUri(CLARK_SERVICE_URI),
     },
     {
         method: HTTPMethod.PATCH,


### PR DESCRIPTION
# Description

This PR just updates the target for adding a learning outcome to a learning object.

Outside of this PR I also updated the learning object service refactor branch. There were changes in clark-service-refactor that learning-object-service-refactor didn't pull. This was the reason development environments were missing ENVs.