### PR TITLE
sc-29052: update the route for getting a list of materials

### DIFF
--- a/src/modules/clark/learning-object-module/learning-objects.routes.ts
+++ b/src/modules/clark/learning-object-module/learning-objects.routes.ts
@@ -88,11 +88,12 @@ export const LEARNING_OBJECTS_ROUTES: ProxyRoute[] = [
         method: HTTPMethod.GET,
         path: "/learning-objects/:id/files/:fileId/download",
         auth: true,
-        target: envConfig.getUri(CLARK_SERVICE_URI)
+        target: envConfig.getUri(CLARK_SERVICE_URI),
     },
     {
         method: HTTPMethod.GET,
-        path: "/users/:username/learning-objects/:id/materials",
+        path: "/learning-objects/:id/materials",
+        target: envConfig.getUri(CLARK_SERVICE_URI),
     },
     {
         method: HTTPMethod.POST,


### PR DESCRIPTION
This updates the route for getting a list of materials for a learning object. See https://github.com/Cyber4All/clark-service/pull/119