### PR TITLE
Implement getting a learning objects children [sc-29053]

### DIFF
--- a/src/modules/clark/learning-object-module/learning-objects.routes.ts
+++ b/src/modules/clark/learning-object-module/learning-objects.routes.ts
@@ -137,7 +137,8 @@ export const LEARNING_OBJECTS_ROUTES: ProxyRoute[] = [
     },
     {
         method: HTTPMethod.GET,
-        path: "/users/:username/learning-objects/:id/children",
+        path: "/learning-objects/:id/children",
+        target: envConfig.getUri(CLARK_SERVICE_URI),
     },
     {
         method: HTTPMethod.GET,


### PR DESCRIPTION
Gateway change for getting a learning objects children. [Story](https://app.shortcut.com/clarkcan/story/29053/implement-getting-a-learning-objects-children-in-clark-service)