### PR TITLE
Feature/sc 32286/implement getting a learning object parent

### DIFF
--- a/src/modules/clark/learning-object-module/learning-objects.routes.ts
+++ b/src/modules/clark/learning-object-module/learning-objects.routes.ts
@@ -1,7 +1,7 @@
-import { CLARK_REPORTS_URI, CLARK_SERVICE_URI } from "../../../config/global.env";
+import { envConfig } from "../../../config/env/env.driver";
+import { CLARK_SERVICE_URI } from "../../../config/global.env";
 import { HTTPMethod } from "../../../shared/types/http-method.type";
 import { ProxyRoute } from "../../../shared/types/proxy-route.type";
-import { envConfig } from "../../../config/env/env.driver";
 
 export const LEARNING_OBJECTS_ROUTES: ProxyRoute[] = [
     /**

--- a/src/modules/clark/learning-object-module/learning-objects.routes.ts
+++ b/src/modules/clark/learning-object-module/learning-objects.routes.ts
@@ -1,4 +1,4 @@
-import { CLARK_SERVICE_URI } from "../../../config/global.env";
+import { CLARK_REPORTS_URI, CLARK_SERVICE_URI } from "../../../config/global.env";
 import { HTTPMethod } from "../../../shared/types/http-method.type";
 import { ProxyRoute } from "../../../shared/types/proxy-route.type";
 import { envConfig } from "../../../config/env/env.driver";
@@ -146,7 +146,8 @@ export const LEARNING_OBJECTS_ROUTES: ProxyRoute[] = [
     },
     {
         method: HTTPMethod.GET,
-        path: "/users/:username/learning-objects/:id/parents",
+        path: "/learning-objects/:id/parents",
+        target: envConfig.getUri(CLARK_SERVICE_URI),
     },
     {
         method: HTTPMethod.POST,

--- a/src/modules/clark/learning-object-module/learning-objects.routes.ts
+++ b/src/modules/clark/learning-object-module/learning-objects.routes.ts
@@ -138,7 +138,7 @@ export const LEARNING_OBJECTS_ROUTES: ProxyRoute[] = [
     },
     {
         method: HTTPMethod.GET,
-        path: "/learning-objects/:id/parents",
+        path: "/learning-objects/:learningObjectId/parents",
         target: envConfig.getUri(CLARK_SERVICE_URI),
     },
     {


### PR DESCRIPTION
Gateway route for getting a learning object's parent

https://app.shortcut.com/clarkcan/story/32286/implement-getting-a-learning-object-parent-in-clark-service