### PR TITLE
fix: [sc-32327] Downloading materials returns a 401

### DIFF
--- a/src/modules/clark/learning-object-module/learning-objects.routes.ts
+++ b/src/modules/clark/learning-object-module/learning-objects.routes.ts
@@ -90,7 +90,6 @@ export const LEARNING_OBJECTS_ROUTES: ProxyRoute[] = [
     {
         method: HTTPMethod.GET,
         path: "/learning-objects/:id/files/:fileId/download",
-        auth: true,
         target: envConfig.getUri(CLARK_SERVICE_URI),
     },
     {


### PR DESCRIPTION
The route responsible for downloading files is not an authenticated route.

Story details: https://app.shortcut.com/clarkcan/story/32327