### PR TITLE
Disable auth on materials route

### DIFF
--- a/src/modules/clark/learning-object-module/learning-objects.routes.ts
+++ b/src/modules/clark/learning-object-module/learning-objects.routes.ts
@@ -17,7 +17,6 @@ export const LEARNING_OBJECTS_ROUTES: ProxyRoute[] = [
     {
         method: HTTPMethod.GET,
         path: "/learning-objects/:learningObjectId/materials",
-        auth: true,
     },
     {
         method: HTTPMethod.POST,


### PR DESCRIPTION
https://github.com/Cyber4All/clark-service/pull/187#issuecomment-2273599357

Since auth is turned off for materials, this should allow the materials route to stop sending 401's and letting the client load correctly
