### PR TITLE
Removed get/users Card route from SearchRoutes.ts

### DIFF
--- a/src/modules/card/search/search.routes.ts
+++ b/src/modules/card/search/search.routes.ts
@@ -14,10 +14,5 @@ export const SEARCH_ROUTES: ProxyRoute[] = [
         method: HTTPMethod.GET,
         auth: true,
         path: "/users/:userId/resources",
-    },
-    {
-        method: HTTPMethod.GET,
-        auth: true,
-        path: "/users",
-    },
+    }
 ];


### PR DESCRIPTION
This route should've been removed, it was conflicting with the Clark get /users route in the user.routes.ts file. As part of the CLARD epic, all user routes from Card will now be using the corresponding Clark one. Removing this now lets the Card client call the correct get users from Clark service.