### PR TITLE
Email routes and route handler added for Card service in gateway

### DIFF
--- a/src/modules/card/card.router.ts
+++ b/src/modules/card/card.router.ts
@@ -5,6 +5,7 @@ import { ResourceRouteHandler } from "./resource/resource.router";
 import { SearchRouteHandler } from "./search/search.router";
 import { UpdateRouteHandler } from "./update/update.router";
 import { UtilityRouteHandler } from "./utility/utility.router";
+import { EmailRouteHandler } from "./email/email.router";
 
 export class CardRouteHandler {
     public static build(): Router {
@@ -17,6 +18,7 @@ export class CardRouteHandler {
         router.use(SearchRouteHandler.build());
         router.use(UpdateRouteHandler.build());
         router.use(UtilityRouteHandler.build());
+        router.use(EmailRouteHandler.build());
 
         return router;
     }

--- a/src/modules/card/email/email.router.ts
+++ b/src/modules/card/email/email.router.ts
@@ -1,0 +1,14 @@
+import { Router } from "express";
+import { buildProxyRouter } from "../../../shared/functions/build-proxy-router";
+import { CARD_SERVICE_URI } from "../../../config/global.env";
+import { envConfig } from "../../../config/env/env.driver";
+import { EMAIL_ROUTES } from "./email.routes";
+
+export class EmailRouteHandler {
+    public static build(): Router {
+        return buildProxyRouter(
+            EMAIL_ROUTES,
+            envConfig.getUri(CARD_SERVICE_URI),
+        );
+    }
+}

--- a/src/modules/card/email/email.routes.ts
+++ b/src/modules/card/email/email.routes.ts
@@ -1,0 +1,25 @@
+import { HTTPMethod } from "../../../shared/types/http-method.type";
+import { ProxyRoute } from "../../../shared/types/proxy-route.type";
+
+export const EMAIL_ROUTES: ProxyRoute[] = [
+    {
+        method: HTTPMethod.POST,
+        path: "/users/verify-email",
+    },
+    {
+        method: HTTPMethod.POST,
+        path: "/users/:userId/verify-email-resend",
+    },
+    {
+        method: HTTPMethod.POST,
+        path: "/users/emails/:emailType",
+    },
+    {
+        method: HTTPMethod.POST,
+        path: "/users/reset-password",
+    },
+    {
+        method: HTTPMethod.PATCH,
+        path: "/users/reset-password",
+    }
+];

--- a/src/modules/card/email/email.routes.ts
+++ b/src/modules/card/email/email.routes.ts
@@ -2,9 +2,9 @@ import { HTTPMethod } from "../../../shared/types/http-method.type";
 import { ProxyRoute } from "../../../shared/types/proxy-route.type";
 
 /**
- * only one route present here in which would actually be found in the CARD user route handler, 
- * but we are no longer using CARD user routes apart from this which is for CARD link checking to send emails,
- * so for better naming convention this is kept as EMAIL_ROUTES. Part of CLARD Unified Users Epic.
+ * Note: The emailType route can be found in the `cards-service` user route handler. With the delegation of user 
+ * administration to CLARK it was most appropriate to update the naming convention to EMAIL_ROUTES.
+ * This change was introduced as part of the `CLARD Unified Users Epic`.
  */
 export const EMAIL_ROUTES: ProxyRoute[] = [
     {

--- a/src/modules/card/email/email.routes.ts
+++ b/src/modules/card/email/email.routes.ts
@@ -1,25 +1,14 @@
 import { HTTPMethod } from "../../../shared/types/http-method.type";
 import { ProxyRoute } from "../../../shared/types/proxy-route.type";
 
+/**
+ * only one route present here in which would actually be found in the CARD user route handler, 
+ * but we are no longer using CARD user routes apart from this which is for CARD link checking to send emails,
+ * so for better naming convention this is kept as EMAIL_ROUTES. Part of CLARD Unified Users Epic.
+ */
 export const EMAIL_ROUTES: ProxyRoute[] = [
-    {
-        method: HTTPMethod.POST,
-        path: "/users/verify-email",
-    },
-    {
-        method: HTTPMethod.POST,
-        path: "/users/:userId/verify-email-resend",
-    },
     {
         method: HTTPMethod.POST,
         path: "/users/emails/:emailType",
     },
-    {
-        method: HTTPMethod.POST,
-        path: "/users/reset-password",
-    },
-    {
-        method: HTTPMethod.PATCH,
-        path: "/users/reset-password",
-    }
 ];

--- a/src/modules/clark/learning-object-module/learning-objects.router.ts
+++ b/src/modules/clark/learning-object-module/learning-objects.router.ts
@@ -13,7 +13,6 @@ import { RELEVANCY_ROUTES } from "./relevancy.routes";
 import { SEARCH_ROUTES } from "./search.routes";
 import { SUBMISSIONS_ROUTES } from "./submissions.routes";
 import { TOPICS_ROUTES } from "./topics.routes";
-import { LEGACY_ROUTES } from "./legacy.routes";
 import { REVISIONS_ROUTES } from "./revisions.routes";
 
 export class LearningObjectsRouteHandler {
@@ -31,7 +30,6 @@ export class LearningObjectsRouteHandler {
                 ...SEARCH_ROUTES,
                 ...SUBMISSIONS_ROUTES,
                 ...TOPICS_ROUTES,
-                ...LEGACY_ROUTES,
             ],
             envConfig.getUri(CLARK_SERVICE_URI),
         );


### PR DESCRIPTION
The card route POST - users/emails/:emailType is used for link checking to send emails to users about broken links, it was not added to Gateway after configuring it to have both Clark and Card routes and work as a proxy for the requests. 

2 files were added, Email.routes holding the route, and Email.router which has a build() function the Card router uses. There is only one route added but for organizational purposes the Card routes are to be separated in a way that reflects the Card service, and in Card service this route was not on the same route handler as any of the others we are keeping.