### PR TITLE
Small typo fix

### DIFF
--- a/src/config/global.env.ts
+++ b/src/config/global.env.ts
@@ -28,7 +28,7 @@ export const HIERARCHY_SERVICE_URI = "HIERARCHY_SERVICE_URI";
 /**
  * URI target for the notifications-service
  */
-export const NOTIFICATIONS_SERVICE_URI = "NOTIFICATIONS_SERVICE_URI";
+export const NOTIFICATIONS_SERVICE_URI = "NOTIFICATION_SERVICE_URI";
 
 /**
  * URI target for the reporting-service


### PR DESCRIPTION
The URI for notification-service in gateway included an extra 's', which caused a URI mismatch with the dev environment.