### PR TITLE
feature/sc-35469/swap-clark-service-uri-for-clark-reports

### DIFF
--- a/src/config/env/env.driver.ts
+++ b/src/config/env/env.driver.ts
@@ -5,7 +5,6 @@ import {
 import {
     AWS_JWT_SECRET,
     CARD_SERVICE_URI,
-    CLARK_REPORTS_URI,
     CLARK_SERVICE_URI,
     CORALOGIX_PRIVATE_KEY,
     HIERARCHY_SERVICE_URI,
@@ -26,7 +25,7 @@ dotenv.config();
  * to retrieve the value of the environment variable
  */
 class EnvConfig {
-    constructor(private env: { [k: string]: string | undefined }) {}
+    constructor(private env: { [k: string]: string | undefined }) { }
 
     /**
      * Gets the value of a environment variable
@@ -117,7 +116,6 @@ class EnvConfig {
                 CLARK_SERVICE_URI,
                 HIERARCHY_SERVICE_URI,
                 NOTIFICATIONS_SERVICE_URI,
-                CLARK_REPORTS_URI,
                 STANDARD_GUIDELINES_SERVICE_URI,
                 SECURED_DOWNTIME_SERVICE_URI,
                 CARD_SERVICE_URI,
@@ -142,7 +140,6 @@ const envConfig = new EnvConfig(process.env).ensureValues([
     CLARK_SERVICE_URI,
     HIERARCHY_SERVICE_URI,
     NOTIFICATIONS_SERVICE_URI,
-    CLARK_REPORTS_URI,
     STANDARD_GUIDELINES_SERVICE_URI,
     SECURED_DOWNTIME_SERVICE_URI,
     CARD_SERVICE_URI,

--- a/src/config/global.env.ts
+++ b/src/config/global.env.ts
@@ -31,11 +31,6 @@ export const HIERARCHY_SERVICE_URI = "HIERARCHY_SERVICE_URI";
 export const NOTIFICATIONS_SERVICE_URI = "NOTIFICATIONS_SERVICE_URI";
 
 /**
- * URI target for the reporting-service
- */
-export const CLARK_REPORTS_URI = "CLARK_REPORTS_URI";
-
-/**
  * URI target for the standard-guidelines-service
  */
 export const STANDARD_GUIDELINES_SERVICE_URI =


### PR DESCRIPTION
This removes ```CLARK_REPORTS_URI``` in ```CLARK-Gateway```

If someone could direct me on how to access the prod and staging terragrunt files that would be awesome because the story says those need to be updated as well.



story link: https://app.shortcut.com/clarkcan/story/35469/swap-clark-service-uri-for-clark-reports-uri-in-reports-module-of-clark-gateway
