### PR TITLE
Removed notifications service uri

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2069,7 +2069,6 @@
             "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
             "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "husky": "lib/bin.js"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2069,6 +2069,7 @@
             "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
             "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "husky": "lib/bin.js"
             },

--- a/src/config/env/env.driver.ts
+++ b/src/config/env/env.driver.ts
@@ -10,7 +10,6 @@ import {
     HIERARCHY_SERVICE_URI,
     ISSUER,
     NODE_ENV,
-    NOTIFICATIONS_SERVICE_URI,
     PORT,
     SECURED_DOWNTIME_SERVICE_URI,
     STANDARD_GUIDELINES_SERVICE_URI,
@@ -114,8 +113,6 @@ class EnvConfig {
         if (
             ![
                 CLARK_SERVICE_URI,
-                HIERARCHY_SERVICE_URI,
-                NOTIFICATIONS_SERVICE_URI,
                 STANDARD_GUIDELINES_SERVICE_URI,
                 SECURED_DOWNTIME_SERVICE_URI,
                 CARD_SERVICE_URI,
@@ -139,7 +136,6 @@ const envConfig = new EnvConfig(process.env).ensureValues([
     // =====================
     CLARK_SERVICE_URI,
     HIERARCHY_SERVICE_URI,
-    NOTIFICATIONS_SERVICE_URI,
     STANDARD_GUIDELINES_SERVICE_URI,
     SECURED_DOWNTIME_SERVICE_URI,
     CARD_SERVICE_URI,

--- a/src/config/env/env.driver.ts
+++ b/src/config/env/env.driver.ts
@@ -113,6 +113,7 @@ class EnvConfig {
         if (
             ![
                 CLARK_SERVICE_URI,
+                HIERARCHY_SERVICE_URI,
                 STANDARD_GUIDELINES_SERVICE_URI,
                 SECURED_DOWNTIME_SERVICE_URI,
                 CARD_SERVICE_URI,

--- a/src/config/global.env.ts
+++ b/src/config/global.env.ts
@@ -26,11 +26,6 @@ export const CARD_SERVICE_URI = "CARD_SERVICE_URI";
 export const HIERARCHY_SERVICE_URI = "HIERARCHY_SERVICE_URI";
 
 /**
- * URI target for the notifications-service
- */
-export const NOTIFICATIONS_SERVICE_URI = "NOTIFICATIONS_SERVICE_URI";
-
-/**
  * URI target for the standard-guidelines-service
  */
 export const STANDARD_GUIDELINES_SERVICE_URI =

--- a/src/modules/clark/notification-module/notifications.router.ts
+++ b/src/modules/clark/notification-module/notifications.router.ts
@@ -1,14 +1,14 @@
 import { Router } from "express";
 import { buildProxyRouter } from "../../../shared/functions/build-proxy-router";
 import { NOTIFICATIONS_ROUTES } from "./notifications.routes";
-import { NOTIFICATIONS_SERVICE_URI } from "../../../config/global.env";
+import { CLARK_SERVICE_URI } from "../../../config/global.env";
 import { envConfig } from "../../../config/env/env.driver";
 
 export class NotificationsRouteHandler {
     public static build(): Router {
         return buildProxyRouter(
             NOTIFICATIONS_ROUTES,
-            envConfig.getUri(NOTIFICATIONS_SERVICE_URI),
+            envConfig.getUri(CLARK_SERVICE_URI),
         );
     }
 }

--- a/src/modules/clark/notification-module/notifications.routes.ts
+++ b/src/modules/clark/notification-module/notifications.routes.ts
@@ -2,13 +2,6 @@ import { HTTPMethod } from "../../../shared/types/http-method.type";
 import { ProxyRoute } from "../../../shared/types/proxy-route.type";
 
 export const NOTIFICATIONS_ROUTES: ProxyRoute[] = [
-    /**
-     * The following routes have not been declared by
-     * clark-service yet and will have a different target
-     * than clark-service
-     *
-     * The target for the following routes shoud be notifications-service
-     */
     {
         method: HTTPMethod.GET,
         path: "/users/:username/notifications",


### PR DESCRIPTION
## What this PR does / why we need it

Removing env variable for notification service uri. Notifications service will be removed once this [PR](https://github.com/Cyber4All/clark-service/pull/324) is completed.
