### PR TITLE
feat: [sc-36529] Decouple downtime route from Gateways

### DIFF
--- a/src/config/env/env.driver.ts
+++ b/src/config/env/env.driver.ts
@@ -11,7 +11,6 @@ import {
     ISSUER,
     NODE_ENV,
     PORT,
-    SECURED_DOWNTIME_SERVICE_URI,
     STANDARD_GUIDELINES_SERVICE_URI,
 } from "../global.env";
 import * as dotenv from "dotenv";
@@ -115,7 +114,6 @@ class EnvConfig {
                 CLARK_SERVICE_URI,
                 HIERARCHY_SERVICE_URI,
                 STANDARD_GUIDELINES_SERVICE_URI,
-                SECURED_DOWNTIME_SERVICE_URI,
                 CARD_SERVICE_URI,
             ].includes(service)
         ) {
@@ -138,7 +136,6 @@ const envConfig = new EnvConfig(process.env).ensureValues([
     CLARK_SERVICE_URI,
     HIERARCHY_SERVICE_URI,
     STANDARD_GUIDELINES_SERVICE_URI,
-    SECURED_DOWNTIME_SERVICE_URI,
     CARD_SERVICE_URI,
 ]);
 

--- a/src/config/global.env.ts
+++ b/src/config/global.env.ts
@@ -31,11 +31,6 @@ export const HIERARCHY_SERVICE_URI = "HIERARCHY_SERVICE_URI";
 export const STANDARD_GUIDELINES_SERVICE_URI =
     "STANDARD_GUIDELINES_SERVICE_URI";
 
-/**
- * URI target for the downtime-service
- */
-export const SECURED_DOWNTIME_SERVICE_URI = "SECURED_DOWNTIME_SERVICE_URI";
-
 // ========================================================
 //                        Optional ENVS
 // ========================================================

--- a/src/modules/clark/utility-module/utility.routes.ts
+++ b/src/modules/clark/utility-module/utility.routes.ts
@@ -1,5 +1,3 @@
-import { envConfig } from "../../../config/env/env.driver";
-import { SECURED_DOWNTIME_SERVICE_URI } from "../../../config/global.env";
 import { HTTPMethod } from "../../../shared/types/http-method.type";
 import { ProxyRoute } from "../../../shared/types/proxy-route.type";
 
@@ -23,14 +21,5 @@ export const UTILITY_ROUTES: ProxyRoute[] = [
     {
         method: HTTPMethod.GET,
         path: "/clientversion",
-    },
-
-    /**
-     * SecurEd Downtime Service Route
-     */
-    {
-        method: HTTPMethod.GET,
-        path: "/downtime",
-        target: envConfig.getUri(SECURED_DOWNTIME_SERVICE_URI),
-    },
+    }
 ];


### PR DESCRIPTION
This PR removes the downtime route from the gateway to make the downtime service independent.

Story details: https://app.shortcut.com/clarkcan/story/36529